### PR TITLE
Simplify commit graph layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -27,6 +27,13 @@ interface ContextMenuState {
   commit: GitCommit | null;
 }
 
+interface BranchLane {
+  name: string;
+  color: string;
+  firstCommitIndex: number;
+  lastCommitIndex: number;
+}
+
 interface GraphConnection {
   id: string;
   fromIndex: number;
@@ -36,41 +43,20 @@ interface GraphConnection {
   color: string;
 }
 
+interface LaneConnectionState {
+  incoming: GraphConnection[];
+  outgoing: GraphConnection[];
+  passing: GraphConnection[];
+}
+
 interface ConnectionLine {
   id: string;
   path: string;
   color: string;
 }
 
-interface GraphComputationResult {
-  commitLaneMap: Record<string, number>;
-  commitBranchMap: Record<string, string>;
-  branchColors: Record<string, string>;
-  laneCount: number;
-  connections: GraphConnection[];
-  laneSegments: (string | null)[][];
-  branchList: { name: string; color: string }[];
-}
-
 const LANE_COLUMN_WIDTH = 72;
-
-const MAIN_BRANCH_KEYS = ['main', 'master'];
-
-const normalizeBranchName = (branch: string): string =>
-  branch
-    .replace(/^refs\/(heads|remotes)\//, '')
-    .replace(/^origin\//, '')
-    .trim();
-
-const canonicalBranchName = (branch: string): string => {
-  const normalized = normalizeBranchName(branch).toLowerCase();
-
-  if (MAIN_BRANCH_KEYS.includes(normalized)) {
-    return 'main';
-  }
-
-  return normalizeBranchName(branch);
-};
+const LINE_OFFSET = 6;
 
 const getBranchColor = (branchName: string): string => {
   const predefined: Record<string, string> = {
@@ -94,220 +80,6 @@ const getBranchColor = (branchName: string): string => {
   }
   const hue = Math.abs(hash) % 360;
   return `hsl(${hue}, 70%, 60%)`;
-};
-
-const computeGraphData = (sortedCommits: GitCommit[]): GraphComputationResult => {
-  const commitLaneMap: Record<string, number> = {};
-  const commitBranchMap: Record<string, string> = {};
-  const branchColors: Record<string, string> = {};
-  const branchNames = new Set<string>();
-  const connections: GraphConnection[] = [];
-
-  if (sortedCommits.length === 0) {
-    return {
-      commitLaneMap,
-      commitBranchMap,
-      branchColors,
-      laneCount: 0,
-      connections,
-      laneSegments: [],
-      branchList: []
-    };
-  }
-
-  const chronological = [...sortedCommits].reverse();
-  const branchToLane = new Map<string, number>();
-  const laneOccupancy: (string | null)[] = [];
-
-  branchToLane.set('main', 0);
-  laneOccupancy[0] = 'main';
-
-  const findNearestFreeLane = (): number => {
-    for (let laneIndex = 1; laneIndex < laneOccupancy.length; laneIndex += 1) {
-      if (!laneOccupancy[laneIndex]) {
-        return laneIndex;
-      }
-    }
-
-    laneOccupancy.push(null);
-    return laneOccupancy.length - 1;
-  };
-
-  const determineBranchForCommit = (commit: GitCommit): string => {
-    if (commit.branches.length > 0) {
-      const normalized = commit.branches.map(canonicalBranchName);
-      const mainBranch = normalized.find((name) => name === 'main');
-
-      if (mainBranch) {
-        return 'main';
-      }
-
-      return normalized[0];
-    }
-
-    for (const parentId of commit.parents) {
-      const parentBranch = commitBranchMap[parentId];
-      if (parentBranch) {
-        return parentBranch;
-      }
-    }
-
-    return 'detached';
-  };
-
-  let maxLaneIndex = 0;
-
-  chronological.forEach((commit) => {
-    const branchName = determineBranchForCommit(commit);
-    branchNames.add(branchName);
-
-    let laneIndex: number;
-
-    if (branchName === 'main') {
-      laneIndex = 0;
-    } else {
-      const existingLane = branchToLane.get(branchName);
-      laneIndex = existingLane ?? findNearestFreeLane();
-    }
-
-    branchToLane.set(branchName, laneIndex);
-    laneOccupancy[laneIndex] = branchName;
-
-    commitLaneMap[commit.id] = laneIndex;
-    commitBranchMap[commit.id] = branchName;
-    maxLaneIndex = Math.max(maxLaneIndex, laneIndex);
-
-    if (commit.parents.length > 1) {
-      const releases = new Map<string, number>();
-
-      commit.parents.forEach((parentId) => {
-        const parentBranch = commitBranchMap[parentId];
-
-        if (!parentBranch || parentBranch === branchName || parentBranch === 'main') {
-          return;
-        }
-
-        const parentLane = branchToLane.get(parentBranch);
-
-        if (parentLane === undefined) {
-          return;
-        }
-
-        releases.set(parentBranch, parentLane);
-      });
-
-      releases.forEach((laneToFree, branchToFree) => {
-        branchToLane.delete(branchToFree);
-        laneOccupancy[laneToFree] = null;
-      });
-    }
-  });
-
-  branchNames.add('main');
-
-  const laneCount = Math.max(maxLaneIndex + 1, branchNames.size > 0 ? 1 : 0);
-
-  branchNames.forEach((branch) => {
-    if (branch === 'detached') {
-      branchColors[branch] = '#9CA3AF';
-      return;
-    }
-
-    if (branch === 'main') {
-      branchColors[branch] = getBranchColor('main');
-      return;
-    }
-
-    branchColors[branch] = getBranchColor(branch);
-  });
-
-  const commitIndexMap: Record<string, number> = {};
-  sortedCommits.forEach((commit, index) => {
-    commitIndexMap[commit.id] = index;
-  });
-
-  sortedCommits.forEach((commit, fromIndex) => {
-    const fromLane = commitLaneMap[commit.id];
-    const branchName = commitBranchMap[commit.id];
-    const color = branchColors[branchName] ?? '#6B7280';
-
-    commit.parents.forEach((parentId) => {
-      const toIndex = commitIndexMap[parentId];
-
-      if (toIndex === undefined) {
-        return;
-      }
-
-      const toLane = commitLaneMap[parentId] ?? fromLane;
-
-      connections.push({
-        id: `${commit.id}-${parentId}`,
-        fromIndex,
-        toIndex,
-        fromLane,
-        toLane,
-        color
-      });
-    });
-  });
-
-  const laneSegments = sortedCommits.map(() => Array<string | null>(laneCount).fill(null));
-
-  sortedCommits.forEach((commit, rowIndex) => {
-    const laneIndex = commitLaneMap[commit.id];
-
-    if (laneIndex === undefined) {
-      return;
-    }
-
-    const branchName = commitBranchMap[commit.id];
-    laneSegments[rowIndex][laneIndex] = branchColors[branchName] ?? '#6B7280';
-  });
-
-  connections.forEach(({ fromIndex, toIndex, fromLane, toLane, color }) => {
-    const start = Math.min(fromIndex, toIndex);
-    const end = Math.max(fromIndex, toIndex);
-
-    for (let row = start; row <= end; row += 1) {
-      const laneIndex = row === toIndex ? toLane : fromLane;
-
-      if (laneSegments[row]) {
-        laneSegments[row][laneIndex] = color;
-      }
-    }
-
-    if (laneSegments[toIndex]) {
-      laneSegments[toIndex][fromLane] = color;
-    }
-  });
-
-  const branchList = Array.from(branchNames)
-    .filter((name) => name !== 'detached')
-    .map((name) => ({
-      name,
-      color: branchColors[name] ?? getBranchColor(name)
-    }))
-    .sort((a, b) => {
-      if (a.name === 'main') {
-        return -1;
-      }
-
-      if (b.name === 'main') {
-        return 1;
-      }
-
-      return a.name.localeCompare(b.name);
-    });
-
-  return {
-    commitLaneMap,
-    commitBranchMap,
-    branchColors,
-    laneCount,
-    connections,
-    laneSegments,
-    branchList
-  };
 };
 
 export const CommitGraph: React.FC<CommitGraphProps> = ({
@@ -335,15 +107,90 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     [commits]
   );
 
-  const {
-    commitLaneMap,
-    commitBranchMap,
-    branchColors,
-    laneCount,
-    connections,
-    laneSegments,
-    branchList
-  } = useMemo(() => computeGraphData(sortedCommits), [sortedCommits]);
+  const { branchLanes, commitLaneMap, laneStates, connections } = useMemo(() => {
+    const lanes: BranchLane[] = [];
+    const laneIndexByName: Record<string, number> = {};
+    const laneMap: Record<string, number> = {};
+    const commitIndexMap: Record<string, number> = {};
+
+    sortedCommits.forEach((commit, index) => {
+      const primaryBranch = commit.branches[0] || 'detached';
+      commitIndexMap[commit.id] = index;
+
+      if (laneIndexByName[primaryBranch] === undefined) {
+        laneIndexByName[primaryBranch] = lanes.length;
+        lanes.push({
+          name: primaryBranch,
+          color: getBranchColor(primaryBranch),
+          firstCommitIndex: index,
+          lastCommitIndex: index
+        });
+      } else {
+        const lane = lanes[laneIndexByName[primaryBranch]];
+        lane.lastCommitIndex = Math.max(lane.lastCommitIndex, index);
+      }
+
+      laneMap[commit.id] = laneIndexByName[primaryBranch];
+    });
+
+    const connectionStates: LaneConnectionState[][] = sortedCommits.map(() =>
+      lanes.map(() => ({ incoming: [], outgoing: [], passing: [] }))
+    );
+
+    const connections: GraphConnection[] = [];
+
+    sortedCommits.forEach((commit, fromIndex) => {
+      const fromLane = laneMap[commit.id];
+
+      if (fromLane === undefined) {
+        return;
+      }
+
+      commit.parents.forEach((parentId) => {
+        const toIndex = commitIndexMap[parentId];
+
+        if (toIndex === undefined) {
+          return;
+        }
+
+        const toLane = laneMap[parentId] ?? fromLane;
+        const color = lanes[fromLane]?.color ?? '#6B7280';
+        const connection: GraphConnection = {
+          id: `${commit.id}-${parentId}`,
+          fromIndex,
+          toIndex,
+          fromLane,
+          toLane,
+          color
+        };
+
+        connections.push(connection);
+      });
+    });
+
+    connections.forEach((connection) => {
+      const { fromIndex, toIndex, fromLane, toLane } = connection;
+
+      const fromLaneState = connectionStates[fromIndex]?.[fromLane];
+      const toLaneState = connectionStates[toIndex]?.[toLane];
+
+      fromLaneState?.outgoing.push(connection);
+
+      for (let row = fromIndex + 1; row < toIndex; row += 1) {
+        const passingLaneState = connectionStates[row]?.[fromLane];
+        passingLaneState?.passing.push(connection);
+      }
+
+      toLaneState?.incoming.push(connection);
+    });
+
+    return {
+      branchLanes: lanes,
+      commitLaneMap: laneMap,
+      laneStates: connectionStates,
+      connections
+    };
+  }, [sortedCommits]);
 
   const registerNodeRef = useCallback(
     (commitId: string) => (element: HTMLDivElement | null) => {
@@ -467,39 +314,137 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     return () => document.removeEventListener('click', handleGlobalClick);
   }, [contextMenu.show, handleCloseContextMenu]);
 
-  const laneColumnTemplate = useMemo(
-    () => (laneCount > 0 ? `repeat(${laneCount}, ${LANE_COLUMN_WIDTH}px)` : ''),
-    [laneCount]
+  const timelineColumns = useMemo(
+    () =>
+      branchLanes.length > 0
+        ? `repeat(${branchLanes.length}, ${LANE_COLUMN_WIDTH}px)`
+        : '1fr',
+    [branchLanes.length]
   );
 
   const renderLaneCell = (
     commit: GitCommit,
+    lane: BranchLane,
     laneIndex: number,
     rowIndex: number
   ) => {
     const commitLane = commitLaneMap[commit.id];
-    const isCommitLane = commitLane === laneIndex;
-    const branchName = commitBranchMap[commit.id];
-    const commitColor = branchColors[branchName] ?? '#6B7280';
-    const laneColor = laneSegments[rowIndex]?.[laneIndex];
+    const isCommitLane = laneIndex === commitLane;
+    const laneState = laneStates[rowIndex]?.[laneIndex];
+    const incoming = laneState?.incoming ?? [];
+    const outgoing = laneState?.outgoing ?? [];
+    const passing = laneState?.passing ?? [];
+
+    const verticalSegments = [
+      ...passing.map((connection) => ({
+        color: connection.color,
+        top: 0,
+        height: '100%'
+      })),
+      ...outgoing.map((connection) => ({
+        color: connection.color,
+        top: '50%',
+        height: '50%'
+      }))
+    ];
+
+    // Render horizontal incoming connections from other lanes
+    const horizontalIncoming = incoming.filter(
+      (connection) => connection.fromLane !== laneIndex
+    );
+    // Render vertical incoming connections from same lane
+    const verticalIncoming = incoming.filter(
+      (connection) => connection.fromLane === laneIndex
+    );
+
+    const getOffset = (index: number, total: number) =>
+      (index - (total - 1) / 2) * LINE_OFFSET;
 
     return (
-      <div key={`lane-${laneIndex}`} className="relative flex items-center justify-center py-6">
-        {laneColor && (
-          <div
-            className="absolute top-0 left-1/2 h-full w-1 -translate-x-1/2 rounded-full"
-            style={{
-              backgroundColor: laneColor,
-              opacity: isCommitLane ? 0.6 : 0.25
-            }}
-          />
-        )}
+      <div key={lane.name} className="relative flex items-center justify-center py-6">
+        {/* Vertical segments for passing/outgoing */}
+        {verticalSegments.map((segment, index) => {
+          const offset = getOffset(index, verticalSegments.length);
+          return (
+            <div
+              key={`segment-${index}`}
+              className="absolute w-1 rounded-full"
+              style={{
+                left: `calc(50% + ${offset}px)`,
+                top: segment.top,
+                height: segment.height,
+                backgroundColor: segment.color,
+                opacity: 0.35
+              }}
+            />
+          );
+        })}
+
+        {/* Vertical incoming connections from same lane */}
+        {verticalIncoming.map((connection, index) => {
+          const offset = getOffset(index, verticalIncoming.length);
+          return (
+            <div
+              key={`vertical-incoming-${index}`}
+              className="absolute w-1 rounded-full"
+              style={{
+                left: `calc(50% + ${offset}px)`,
+                top: 0,
+                height: '50%',
+                backgroundColor: connection.color,
+                opacity: 0.35
+              }}
+            />
+          );
+        })}
+
+        {/* Horizontal incoming connections from other lanes */}
+        {horizontalIncoming.map((connection, index) => {
+          // Determine direction: left or right
+          const direction = connection.fromLane < laneIndex ? 'left' : 'right';
+          const laneDiff = Math.abs(connection.fromLane - laneIndex);
+          const horizontalOffset = laneDiff * LANE_COLUMN_WIDTH;
+          const color = connection.color;
+          // Offset for stacking multiple horizontal lines
+          const stackOffset = getOffset(index, horizontalIncoming.length);
+          return (
+            <>
+              {/* Horizontal segment from source lane to current lane */}
+              <div
+                key={`horizontal-incoming-h-${index}`}
+                className="absolute h-1 rounded-full"
+                style={{
+                  top: `0`,
+                  left:
+                    direction === 'left'
+                      ? `calc(50% - ${horizontalOffset}px + ${stackOffset}px)`
+                      : `calc(50% + ${stackOffset}px)`,
+                  width: `${horizontalOffset}px`,
+                  backgroundColor: color,
+                  opacity: 0.35
+                }}
+              />
+              {/* Vertical segment down to node */}
+              <div
+                key={`horizontal-incoming-v-${index}`}
+                className="absolute w-1 rounded-full"
+                style={{
+                  left: `calc(50% + ${stackOffset}px)`,
+                  top: 0,
+                  height: '50%',
+                  backgroundColor: color,
+                  opacity: 0.35
+                }}
+              />
+            </>
+          );
+        })}
 
         {isCommitLane && (
           <div ref={registerNodeRef(commit.id)} className="relative z-20">
             <CommitNode
               commit={commit}
-              branchColor={commitColor}
+              branchColor={lane.color}
               onClick={() => onCommitClick(commit)}
               onContextMenu={(event) => handleContextMenu(event, commit)}
             />
@@ -510,21 +455,19 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   };
 
   const renderCommitRow = (commit: GitCommit, index: number) => {
-    const gridTemplate =
-      laneCount > 0
-        ? `${laneColumnTemplate} minmax(0, 1fr)`
-        : 'minmax(0, 1fr)';
-
     return (
       <div
         key={commit.id}
         className="grid border-b border-gray-800 bg-gray-900/60 hover:bg-gray-900 transition-colors"
-        style={{ gridTemplateColumns: gridTemplate }}
+        style={{ gridTemplateColumns: `${timelineColumns} minmax(0, 1fr)` }}
       >
-        {laneCount > 0 &&
-          Array.from({ length: laneCount }, (_, laneIndex) =>
-            renderLaneCell(commit, laneIndex, index)
-          )}
+        {branchLanes.length > 0 ? (
+          branchLanes.map((lane, laneIndex) =>
+            renderLaneCell(commit, lane, laneIndex, index)
+          )
+        ) : (
+          <div className="py-6" />
+        )}
 
         <div className="flex flex-col gap-2 py-4 pr-6">
           <div className="flex flex-wrap items-center gap-3">
@@ -538,23 +481,18 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             </button>
 
             <div className="flex flex-wrap items-center gap-2">
-              {commit.branches.map((branch) => {
-                const normalized = canonicalBranchName(branch);
-                const color = branchColors[normalized] ?? getBranchColor(normalized);
-
-                return (
-                  <span
-                    key={`${commit.id}-${branch}`}
-                    className="px-2 py-0.5 text-xs font-medium rounded-full border"
-                    style={{
-                      borderColor: color,
-                      color
-                    }}
+              {commit.branches.map((branch) => (
+                <span
+                  key={`${commit.id}-${branch}`}
+                  className="px-2 py-0.5 text-xs font-medium rounded-full border"
+                  style={{
+                    borderColor: getBranchColor(branch),
+                    color: getBranchColor(branch)
+                  }}
                   >
                     {branch}
                   </span>
-                );
-              })}
+              ))}
 
               {commit.tags.map((tag) => (
                 <span
@@ -574,7 +512,9 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             <span>
               {commit.date.toLocaleDateString()} {commit.date.toLocaleTimeString()}
             </span>
-            <span className="text-green-400">+{commit.stats.additions}</span>
+            <span className="text-green-400">
+              +{commit.stats.additions}
+            </span>
             <span className="text-red-400">-{commit.stats.deletions}</span>
             <span>{commit.files.length} file{commit.files.length === 1 ? '' : 's'}</span>
           </div>
@@ -595,7 +535,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
           </div>
 
           <div className="space-y-3 px-4 py-4">
-            {branchList.map((lane) => (
+            {branchLanes.map((lane) => (
               <div key={lane.name} className="flex items-center gap-3">
                 <span
                   className="h-3 w-3 rounded-full"
@@ -607,7 +547,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
               </div>
             ))}
 
-            {branchList.length === 0 && (
+            {branchLanes.length === 0 && (
               <div className="text-sm text-gray-500">No branches detected</div>
             )}
           </div>

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -3,21 +3,15 @@ import React, {
   useState,
   useCallback,
   useRef,
-  useEffect,
-  useLayoutEffect
+  useEffect
 } from 'react';
 import { GitCommit } from '../types/git';
 import { CommitNode } from './CommitNode';
-import { ContextMenu } from './ContextMenu';
 import { GitBranch, Tag } from 'lucide-react';
 
 interface CommitGraphProps {
   commits: GitCommit[];
   onCommitClick: (commit: GitCommit) => void;
-  onReset: (commitId: string, mode: 'soft' | 'mixed' | 'hard') => void;
-  onCherryPick: (commitId: string) => void;
-  onRevert: (commitId: string) => void;
-  onCreateBranch: (fromCommit: string) => void;
 }
 
 interface ContextMenuState {
@@ -49,14 +43,7 @@ interface LaneConnectionState {
   passing: GraphConnection[];
 }
 
-interface ConnectionLine {
-  id: string;
-  path: string;
-  color: string;
-}
-
 const LANE_COLUMN_WIDTH = 72;
-const LINE_OFFSET = 6;
 
 const getBranchColor = (branchName: string): string => {
   const predefined: Record<string, string> = {
@@ -84,11 +71,7 @@ const getBranchColor = (branchName: string): string => {
 
 export const CommitGraph: React.FC<CommitGraphProps> = ({
   commits,
-  onCommitClick,
-  onReset,
-  onCherryPick,
-  onRevert,
-  onCreateBranch
+  onCommitClick
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
@@ -99,15 +82,14 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     y: 0,
     commit: null
   });
-  const [connectionLines, setConnectionLines] = useState<ConnectionLine[]>([]);
-  const [graphDimensions, setGraphDimensions] = useState({ width: 0, height: 0 });
 
   const sortedCommits = useMemo(
     () => [...commits].sort((a, b) => b.date.getTime() - a.date.getTime()),
     [commits]
   );
 
-  const { branchLanes, commitLaneMap, laneStates, connections } = useMemo(() => {
+  // Calculate lanes and connections
+  const { branchLanes, commitLaneMap, connections } = useMemo(() => {
     const lanes: BranchLane[] = [];
     const laneIndexByName: Record<string, number> = {};
     const laneMap: Record<string, number> = {};
@@ -187,10 +169,51 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     return {
       branchLanes: lanes,
       commitLaneMap: laneMap,
-      laneStates: connectionStates,
       connections
     };
   }, [sortedCommits]);
+
+  // Calculate node positions for SVG
+  const ROW_HEIGHT = 64;
+  const nodePositions = useMemo(() => {
+    const positions: Record<string, { x: number; y: number; lane: number; row: number }> = {};
+    sortedCommits.forEach((commit, rowIndex) => {
+      const laneIndex = commitLaneMap[commit.id];
+      positions[commit.id] = {
+        x: laneIndex * LANE_COLUMN_WIDTH + LANE_COLUMN_WIDTH / 2,
+        y: rowIndex * ROW_HEIGHT + ROW_HEIGHT / 2,
+        lane: laneIndex,
+        row: rowIndex
+      };
+    });
+    return positions;
+  }, [sortedCommits, commitLaneMap]);
+
+  // SVG connection lines
+  const svgConnections = useMemo(() => {
+    const lines: { id: string; path: string; color: string }[] = [];
+    connections.forEach((connection) => {
+      const fromPos = nodePositions[sortedCommits[connection.fromIndex].id];
+      const toPos = nodePositions[sortedCommits[connection.toIndex].id];
+      if (!fromPos || !toPos) return;
+      if (fromPos.lane === toPos.lane) {
+        // Vertical line
+        lines.push({
+          id: connection.id,
+          path: `M ${fromPos.x} ${fromPos.y} L ${toPos.x} ${toPos.y}`,
+          color: connection.color
+        });
+      } else {
+        // Merge: horizontal from parent to child lane, then vertical down
+        lines.push({
+          id: connection.id + '-h',
+          path: `M ${fromPos.x} ${fromPos.y} H ${toPos.x} V ${toPos.y}`,
+          color: connection.color
+        });
+      }
+    });
+    return lines;
+  }, [connections, nodePositions, sortedCommits]);
 
   const registerNodeRef = useCallback(
     (commitId: string) => (element: HTMLDivElement | null) => {
@@ -202,88 +225,6 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     },
     []
   );
-
-  const recomputeConnections = useCallback(() => {
-    const container = timelineRef.current;
-
-    if (!container) {
-      return;
-    }
-
-    const width = container.scrollWidth;
-    const height = container.scrollHeight;
-    const lines: ConnectionLine[] = [];
-
-    connections.forEach((connection) => {
-      const fromCommit = sortedCommits[connection.fromIndex];
-      const toCommit = sortedCommits[connection.toIndex];
-
-      if (!fromCommit || !toCommit) {
-        return;
-      }
-
-      const fromElement = nodeRefs.current[fromCommit.id];
-      const toElement = nodeRefs.current[toCommit.id];
-
-      if (!fromElement || !toElement) {
-        return;
-      }
-
-      const x1 = fromElement.offsetLeft + fromElement.offsetWidth / 2;
-      const y1 = fromElement.offsetTop + fromElement.offsetHeight / 2;
-      const x2 = toElement.offsetLeft + toElement.offsetWidth / 2;
-      const y2 = toElement.offsetTop + toElement.offsetHeight / 2;
-
-      const sameLane = Math.abs(x1 - x2) < 1;
-      const path = sameLane
-        ? `M ${x1} ${y1} L ${x2} ${y2}`
-        : `M ${x1} ${y1} V ${y2} H ${x2}`;
-
-      lines.push({
-        id: connection.id,
-        path,
-        color: connection.color
-      });
-    });
-
-    setGraphDimensions({ width, height });
-    setConnectionLines(lines);
-  }, [connections, sortedCommits]);
-
-  useLayoutEffect(() => {
-    recomputeConnections();
-  }, [recomputeConnections]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      recomputeConnections();
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [recomputeConnections]);
-
-  useEffect(() => {
-    if (typeof ResizeObserver === 'undefined') {
-      return undefined;
-    }
-
-    const container = timelineRef.current;
-
-    if (!container) {
-      return undefined;
-    }
-
-    const observer = new ResizeObserver(() => {
-      recomputeConnections();
-    });
-
-    observer.observe(container);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [recomputeConnections]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent, commit: GitCommit) => {
     e.preventDefault();
@@ -309,7 +250,6 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
         handleCloseContextMenu();
       }
     };
-
     document.addEventListener('click', handleGlobalClick);
     return () => document.removeEventListener('click', handleGlobalClick);
   }, [contextMenu.show, handleCloseContextMenu]);
@@ -325,123 +265,15 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   const renderLaneCell = (
     commit: GitCommit,
     lane: BranchLane,
-    laneIndex: number,
-    rowIndex: number
+    laneIndex: number
   ) => {
     const commitLane = commitLaneMap[commit.id];
     const isCommitLane = laneIndex === commitLane;
-    const laneState = laneStates[rowIndex]?.[laneIndex];
-    const incoming = laneState?.incoming ?? [];
-    const outgoing = laneState?.outgoing ?? [];
-    const passing = laneState?.passing ?? [];
-
-    const verticalSegments = [
-      ...passing.map((connection) => ({
-        color: connection.color,
-        top: 0,
-        height: '100%'
-      })),
-      ...outgoing.map((connection) => ({
-        color: connection.color,
-        top: '50%',
-        height: '50%'
-      }))
-    ];
-
-    // Render horizontal incoming connections from other lanes
-    const horizontalIncoming = incoming.filter(
-      (connection) => connection.fromLane !== laneIndex
-    );
-    // Render vertical incoming connections from same lane
-    const verticalIncoming = incoming.filter(
-      (connection) => connection.fromLane === laneIndex
-    );
-
-    const getOffset = (index: number, total: number) =>
-      (index - (total - 1) / 2) * LINE_OFFSET;
 
     return (
-      <div key={lane.name} className="relative flex items-center justify-center py-6">
-        {/* Vertical segments for passing/outgoing */}
-        {verticalSegments.map((segment, index) => {
-          const offset = getOffset(index, verticalSegments.length);
-          return (
-            <div
-              key={`segment-${index}`}
-              className="absolute w-1 rounded-full"
-              style={{
-                left: `calc(50% + ${offset}px)`,
-                top: segment.top,
-                height: segment.height,
-                backgroundColor: segment.color,
-                opacity: 0.35
-              }}
-            />
-          );
-        })}
-
-        {/* Vertical incoming connections from same lane */}
-        {verticalIncoming.map((connection, index) => {
-          const offset = getOffset(index, verticalIncoming.length);
-          return (
-            <div
-              key={`vertical-incoming-${index}`}
-              className="absolute w-1 rounded-full"
-              style={{
-                left: `calc(50% + ${offset}px)`,
-                top: 0,
-                height: '50%',
-                backgroundColor: connection.color,
-                opacity: 0.35
-              }}
-            />
-          );
-        })}
-
-        {/* Horizontal incoming connections from other lanes */}
-        {horizontalIncoming.map((connection, index) => {
-          // Determine direction: left or right
-          const direction = connection.fromLane < laneIndex ? 'left' : 'right';
-          const laneDiff = Math.abs(connection.fromLane - laneIndex);
-          const horizontalOffset = laneDiff * LANE_COLUMN_WIDTH;
-          const color = connection.color;
-          // Offset for stacking multiple horizontal lines
-          const stackOffset = getOffset(index, horizontalIncoming.length);
-          return (
-            <>
-              {/* Horizontal segment from source lane to current lane */}
-              <div
-                key={`horizontal-incoming-h-${index}`}
-                className="absolute h-1 rounded-full"
-                style={{
-                  top: `0`,
-                  left:
-                    direction === 'left'
-                      ? `calc(50% - ${horizontalOffset}px + ${stackOffset}px)`
-                      : `calc(50% + ${stackOffset}px)`,
-                  width: `${horizontalOffset}px`,
-                  backgroundColor: color,
-                  opacity: 0.35
-                }}
-              />
-              {/* Vertical segment down to node */}
-              <div
-                key={`horizontal-incoming-v-${index}`}
-                className="absolute w-1 rounded-full"
-                style={{
-                  left: `calc(50% + ${stackOffset}px)`,
-                  top: 0,
-                  height: '50%',
-                  backgroundColor: color,
-                  opacity: 0.35
-                }}
-              />
-            </>
-          );
-        })}
-
+      <div key={lane.name} className="relative flex items-center justify-center" style={{ height: ROW_HEIGHT }}>
         {isCommitLane && (
-          <div ref={registerNodeRef(commit.id)} className="relative z-20">
+          <div ref={registerNodeRef(commit.id)} className="relative z-20 flex items-center justify-center" style={{ height: ROW_HEIGHT }}>
             <CommitNode
               commit={commit}
               branchColor={lane.color}
@@ -450,75 +282,6 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             />
           </div>
         )}
-      </div>
-    );
-  };
-
-  const renderCommitRow = (commit: GitCommit, index: number) => {
-    return (
-      <div
-        key={commit.id}
-        className="grid border-b border-gray-800 bg-gray-900/60 hover:bg-gray-900 transition-colors"
-        style={{ gridTemplateColumns: `${timelineColumns} minmax(0, 1fr)` }}
-      >
-        {branchLanes.length > 0 ? (
-          branchLanes.map((lane, laneIndex) =>
-            renderLaneCell(commit, lane, laneIndex, index)
-          )
-        ) : (
-          <div className="py-6" />
-        )}
-
-        <div className="flex flex-col gap-2 py-4 pr-6">
-          <div className="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              onClick={() => onCommitClick(commit)}
-              onContextMenu={(event) => handleContextMenu(event, commit)}
-              className="text-left text-sm font-semibold text-gray-100 hover:text-white"
-            >
-              {commit.message}
-            </button>
-
-            <div className="flex flex-wrap items-center gap-2">
-              {commit.branches.map((branch) => (
-                <span
-                  key={`${commit.id}-${branch}`}
-                  className="px-2 py-0.5 text-xs font-medium rounded-full border"
-                  style={{
-                    borderColor: getBranchColor(branch),
-                    color: getBranchColor(branch)
-                  }}
-                  >
-                    {branch}
-                  </span>
-              ))}
-
-              {commit.tags.map((tag) => (
-                <span
-                  key={`${commit.id}-${tag}`}
-                  className="inline-flex items-center gap-1 rounded-full bg-yellow-600/20 px-2 py-0.5 text-xs font-medium text-yellow-200"
-                >
-                  <Tag className="h-3 w-3" />
-                  {tag}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-400">
-            <span className="font-mono text-gray-300">{commit.shortHash}</span>
-            <span>{commit.author.name}</span>
-            <span>
-              {commit.date.toLocaleDateString()} {commit.date.toLocaleTimeString()}
-            </span>
-            <span className="text-green-400">
-              +{commit.stats.additions}
-            </span>
-            <span className="text-red-400">-{commit.stats.deletions}</span>
-            <span>{commit.files.length} file{commit.files.length === 1 ? '' : 's'}</span>
-          </div>
-        </div>
       </div>
     );
   };
@@ -533,7 +296,6 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
               Branches
             </h3>
           </div>
-
           <div className="space-y-3 px-4 py-4">
             {branchLanes.map((lane) => (
               <div key={lane.name} className="flex items-center gap-3">
@@ -546,56 +308,102 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                 </span>
               </div>
             ))}
-
             {branchLanes.length === 0 && (
               <div className="text-sm text-gray-500">No branches detected</div>
             )}
           </div>
         </div>
-
         <div className="flex-1 overflow-auto">
           <div
             ref={timelineRef}
             className="relative min-w-full divide-y divide-gray-800"
+            style={{ height: sortedCommits.length * ROW_HEIGHT }}
           >
-            {graphDimensions.width > 0 && graphDimensions.height > 0 && (
-              <svg
-                className="pointer-events-none absolute inset-0 z-10"
-                width={graphDimensions.width}
-                height={graphDimensions.height}
-                viewBox={`0 0 ${graphDimensions.width} ${graphDimensions.height}`}
+            {/* SVG overlay for all connections */}
+            <svg
+              className="pointer-events-none absolute inset-0 z-10"
+              width={branchLanes.length * LANE_COLUMN_WIDTH}
+              height={sortedCommits.length * ROW_HEIGHT}
+              viewBox={`0 0 ${branchLanes.length * LANE_COLUMN_WIDTH} ${sortedCommits.length * ROW_HEIGHT}`}
+            >
+              {svgConnections.map((line) => (
+                <path
+                  key={line.id}
+                  d={line.path}
+                  stroke={line.color}
+                  strokeWidth={4}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                  opacity={0.7}
+                />
+              ))}
+            </svg>
+            {sortedCommits.map((commit) => (
+              <div
+                key={commit.id}
+                className="grid border-b border-gray-800 bg-gray-900/60 hover:bg-gray-900 transition-colors"
+                style={{ gridTemplateColumns: `${timelineColumns} minmax(0, 1fr)`, height: ROW_HEIGHT }}
               >
-                {connectionLines.map((line) => (
-                  <path
-                    key={line.id}
-                    d={line.path}
-                    stroke={line.color}
-                    strokeWidth={4}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    fill="none"
-                    opacity={0.45}
-                  />
-                ))}
-              </svg>
-            )}
-            {sortedCommits.map((commit, index) => renderCommitRow(commit, index))}
+                {branchLanes.length > 0 ? (
+                  branchLanes.map((lane, laneIndex) =>
+                    renderLaneCell(commit, lane, laneIndex)
+                  )
+                ) : (
+                  <div style={{ height: ROW_HEIGHT }} />
+                )}
+                <div className="flex flex-col gap-2 py-4 pr-6">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => onCommitClick(commit)}
+                      onContextMenu={(event) => handleContextMenu(event, commit)}
+                      className="text-left text-sm font-semibold text-gray-100 hover:text-white"
+                    >
+                      {commit.message}
+                    </button>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {commit.branches.map((branch) => (
+                        <span
+                          key={`${commit.id}-${branch}`}
+                          className="px-2 py-0.5 text-xs font-medium rounded-full border"
+                          style={{
+                            borderColor: getBranchColor(branch),
+                            color: getBranchColor(branch)
+                          }}
+                        >
+                          {branch}
+                        </span>
+                      ))}
+                      {commit.tags.map((tag) => (
+                        <span
+                          key={`${commit.id}-${tag}`}
+                          className="inline-flex items-center gap-1 rounded-full bg-yellow-600/20 px-2 py-0.5 text-xs font-medium text-yellow-200"
+                        >
+                          <Tag className="h-3 w-3" />
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-400">
+                    <span className="font-mono text-gray-300">{commit.shortHash}</span>
+                    <span>{commit.author.name}</span>
+                    <span>
+                      {commit.date.toLocaleDateString()} {commit.date.toLocaleTimeString()}
+                    </span>
+                    <span className="text-green-400">
+                      +{commit.stats.additions}
+                    </span>
+                    <span className="text-red-400">-{commit.stats.deletions}</span>
+                    <span>{commit.files.length} file{commit.files.length === 1 ? '' : 's'}</span>
+                  </div>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </div>
-
-      {contextMenu.show && contextMenu.commit && (
-        <ContextMenu
-          x={contextMenu.x}
-          y={contextMenu.y}
-          commit={contextMenu.commit}
-          onReset={onReset}
-          onCherryPick={onCherryPick}
-          onRevert={onRevert}
-          onCreateBranch={onCreateBranch}
-          onClose={handleCloseContextMenu}
-        />
-      )}
     </div>
   );
 };

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -27,13 +27,6 @@ interface ContextMenuState {
   commit: GitCommit | null;
 }
 
-interface BranchLane {
-  name: string;
-  color: string;
-  firstCommitIndex: number;
-  lastCommitIndex: number;
-}
-
 interface GraphConnection {
   id: string;
   fromIndex: number;
@@ -43,20 +36,41 @@ interface GraphConnection {
   color: string;
 }
 
-interface LaneConnectionState {
-  incoming: GraphConnection[];
-  outgoing: GraphConnection[];
-  passing: GraphConnection[];
-}
-
 interface ConnectionLine {
   id: string;
   path: string;
   color: string;
 }
 
+interface GraphComputationResult {
+  commitLaneMap: Record<string, number>;
+  commitBranchMap: Record<string, string>;
+  branchColors: Record<string, string>;
+  laneCount: number;
+  connections: GraphConnection[];
+  laneSegments: (string | null)[][];
+  branchList: { name: string; color: string }[];
+}
+
 const LANE_COLUMN_WIDTH = 72;
-const LINE_OFFSET = 6;
+
+const MAIN_BRANCH_KEYS = ['main', 'master'];
+
+const normalizeBranchName = (branch: string): string =>
+  branch
+    .replace(/^refs\/(heads|remotes)\//, '')
+    .replace(/^origin\//, '')
+    .trim();
+
+const canonicalBranchName = (branch: string): string => {
+  const normalized = normalizeBranchName(branch).toLowerCase();
+
+  if (MAIN_BRANCH_KEYS.includes(normalized)) {
+    return 'main';
+  }
+
+  return normalizeBranchName(branch);
+};
 
 const getBranchColor = (branchName: string): string => {
   const predefined: Record<string, string> = {
@@ -80,6 +94,220 @@ const getBranchColor = (branchName: string): string => {
   }
   const hue = Math.abs(hash) % 360;
   return `hsl(${hue}, 70%, 60%)`;
+};
+
+const computeGraphData = (sortedCommits: GitCommit[]): GraphComputationResult => {
+  const commitLaneMap: Record<string, number> = {};
+  const commitBranchMap: Record<string, string> = {};
+  const branchColors: Record<string, string> = {};
+  const branchNames = new Set<string>();
+  const connections: GraphConnection[] = [];
+
+  if (sortedCommits.length === 0) {
+    return {
+      commitLaneMap,
+      commitBranchMap,
+      branchColors,
+      laneCount: 0,
+      connections,
+      laneSegments: [],
+      branchList: []
+    };
+  }
+
+  const chronological = [...sortedCommits].reverse();
+  const branchToLane = new Map<string, number>();
+  const laneOccupancy: (string | null)[] = [];
+
+  branchToLane.set('main', 0);
+  laneOccupancy[0] = 'main';
+
+  const findNearestFreeLane = (): number => {
+    for (let laneIndex = 1; laneIndex < laneOccupancy.length; laneIndex += 1) {
+      if (!laneOccupancy[laneIndex]) {
+        return laneIndex;
+      }
+    }
+
+    laneOccupancy.push(null);
+    return laneOccupancy.length - 1;
+  };
+
+  const determineBranchForCommit = (commit: GitCommit): string => {
+    if (commit.branches.length > 0) {
+      const normalized = commit.branches.map(canonicalBranchName);
+      const mainBranch = normalized.find((name) => name === 'main');
+
+      if (mainBranch) {
+        return 'main';
+      }
+
+      return normalized[0];
+    }
+
+    for (const parentId of commit.parents) {
+      const parentBranch = commitBranchMap[parentId];
+      if (parentBranch) {
+        return parentBranch;
+      }
+    }
+
+    return 'detached';
+  };
+
+  let maxLaneIndex = 0;
+
+  chronological.forEach((commit) => {
+    const branchName = determineBranchForCommit(commit);
+    branchNames.add(branchName);
+
+    let laneIndex: number;
+
+    if (branchName === 'main') {
+      laneIndex = 0;
+    } else {
+      const existingLane = branchToLane.get(branchName);
+      laneIndex = existingLane ?? findNearestFreeLane();
+    }
+
+    branchToLane.set(branchName, laneIndex);
+    laneOccupancy[laneIndex] = branchName;
+
+    commitLaneMap[commit.id] = laneIndex;
+    commitBranchMap[commit.id] = branchName;
+    maxLaneIndex = Math.max(maxLaneIndex, laneIndex);
+
+    if (commit.parents.length > 1) {
+      const releases = new Map<string, number>();
+
+      commit.parents.forEach((parentId) => {
+        const parentBranch = commitBranchMap[parentId];
+
+        if (!parentBranch || parentBranch === branchName || parentBranch === 'main') {
+          return;
+        }
+
+        const parentLane = branchToLane.get(parentBranch);
+
+        if (parentLane === undefined) {
+          return;
+        }
+
+        releases.set(parentBranch, parentLane);
+      });
+
+      releases.forEach((laneToFree, branchToFree) => {
+        branchToLane.delete(branchToFree);
+        laneOccupancy[laneToFree] = null;
+      });
+    }
+  });
+
+  branchNames.add('main');
+
+  const laneCount = Math.max(maxLaneIndex + 1, branchNames.size > 0 ? 1 : 0);
+
+  branchNames.forEach((branch) => {
+    if (branch === 'detached') {
+      branchColors[branch] = '#9CA3AF';
+      return;
+    }
+
+    if (branch === 'main') {
+      branchColors[branch] = getBranchColor('main');
+      return;
+    }
+
+    branchColors[branch] = getBranchColor(branch);
+  });
+
+  const commitIndexMap: Record<string, number> = {};
+  sortedCommits.forEach((commit, index) => {
+    commitIndexMap[commit.id] = index;
+  });
+
+  sortedCommits.forEach((commit, fromIndex) => {
+    const fromLane = commitLaneMap[commit.id];
+    const branchName = commitBranchMap[commit.id];
+    const color = branchColors[branchName] ?? '#6B7280';
+
+    commit.parents.forEach((parentId) => {
+      const toIndex = commitIndexMap[parentId];
+
+      if (toIndex === undefined) {
+        return;
+      }
+
+      const toLane = commitLaneMap[parentId] ?? fromLane;
+
+      connections.push({
+        id: `${commit.id}-${parentId}`,
+        fromIndex,
+        toIndex,
+        fromLane,
+        toLane,
+        color
+      });
+    });
+  });
+
+  const laneSegments = sortedCommits.map(() => Array<string | null>(laneCount).fill(null));
+
+  sortedCommits.forEach((commit, rowIndex) => {
+    const laneIndex = commitLaneMap[commit.id];
+
+    if (laneIndex === undefined) {
+      return;
+    }
+
+    const branchName = commitBranchMap[commit.id];
+    laneSegments[rowIndex][laneIndex] = branchColors[branchName] ?? '#6B7280';
+  });
+
+  connections.forEach(({ fromIndex, toIndex, fromLane, toLane, color }) => {
+    const start = Math.min(fromIndex, toIndex);
+    const end = Math.max(fromIndex, toIndex);
+
+    for (let row = start; row <= end; row += 1) {
+      const laneIndex = row === toIndex ? toLane : fromLane;
+
+      if (laneSegments[row]) {
+        laneSegments[row][laneIndex] = color;
+      }
+    }
+
+    if (laneSegments[toIndex]) {
+      laneSegments[toIndex][fromLane] = color;
+    }
+  });
+
+  const branchList = Array.from(branchNames)
+    .filter((name) => name !== 'detached')
+    .map((name) => ({
+      name,
+      color: branchColors[name] ?? getBranchColor(name)
+    }))
+    .sort((a, b) => {
+      if (a.name === 'main') {
+        return -1;
+      }
+
+      if (b.name === 'main') {
+        return 1;
+      }
+
+      return a.name.localeCompare(b.name);
+    });
+
+  return {
+    commitLaneMap,
+    commitBranchMap,
+    branchColors,
+    laneCount,
+    connections,
+    laneSegments,
+    branchList
+  };
 };
 
 export const CommitGraph: React.FC<CommitGraphProps> = ({
@@ -107,90 +335,15 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     [commits]
   );
 
-  const { branchLanes, commitLaneMap, laneStates, connections } = useMemo(() => {
-    const lanes: BranchLane[] = [];
-    const laneIndexByName: Record<string, number> = {};
-    const laneMap: Record<string, number> = {};
-    const commitIndexMap: Record<string, number> = {};
-
-    sortedCommits.forEach((commit, index) => {
-      const primaryBranch = commit.branches[0] || 'detached';
-      commitIndexMap[commit.id] = index;
-
-      if (laneIndexByName[primaryBranch] === undefined) {
-        laneIndexByName[primaryBranch] = lanes.length;
-        lanes.push({
-          name: primaryBranch,
-          color: getBranchColor(primaryBranch),
-          firstCommitIndex: index,
-          lastCommitIndex: index
-        });
-      } else {
-        const lane = lanes[laneIndexByName[primaryBranch]];
-        lane.lastCommitIndex = Math.max(lane.lastCommitIndex, index);
-      }
-
-      laneMap[commit.id] = laneIndexByName[primaryBranch];
-    });
-
-    const connectionStates: LaneConnectionState[][] = sortedCommits.map(() =>
-      lanes.map(() => ({ incoming: [], outgoing: [], passing: [] }))
-    );
-
-    const connections: GraphConnection[] = [];
-
-    sortedCommits.forEach((commit, fromIndex) => {
-      const fromLane = laneMap[commit.id];
-
-      if (fromLane === undefined) {
-        return;
-      }
-
-      commit.parents.forEach((parentId) => {
-        const toIndex = commitIndexMap[parentId];
-
-        if (toIndex === undefined) {
-          return;
-        }
-
-        const toLane = laneMap[parentId] ?? fromLane;
-        const color = lanes[fromLane]?.color ?? '#6B7280';
-        const connection: GraphConnection = {
-          id: `${commit.id}-${parentId}`,
-          fromIndex,
-          toIndex,
-          fromLane,
-          toLane,
-          color
-        };
-
-        connections.push(connection);
-      });
-    });
-
-    connections.forEach((connection) => {
-      const { fromIndex, toIndex, fromLane, toLane } = connection;
-
-      const fromLaneState = connectionStates[fromIndex]?.[fromLane];
-      const toLaneState = connectionStates[toIndex]?.[toLane];
-
-      fromLaneState?.outgoing.push(connection);
-
-      for (let row = fromIndex + 1; row < toIndex; row += 1) {
-        const passingLaneState = connectionStates[row]?.[fromLane];
-        passingLaneState?.passing.push(connection);
-      }
-
-      toLaneState?.incoming.push(connection);
-    });
-
-    return {
-      branchLanes: lanes,
-      commitLaneMap: laneMap,
-      laneStates: connectionStates,
-      connections
-    };
-  }, [sortedCommits]);
+  const {
+    commitLaneMap,
+    commitBranchMap,
+    branchColors,
+    laneCount,
+    connections,
+    laneSegments,
+    branchList
+  } = useMemo(() => computeGraphData(sortedCommits), [sortedCommits]);
 
   const registerNodeRef = useCallback(
     (commitId: string) => (element: HTMLDivElement | null) => {
@@ -314,73 +467,39 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     return () => document.removeEventListener('click', handleGlobalClick);
   }, [contextMenu.show, handleCloseContextMenu]);
 
-  const timelineColumns = useMemo(
-    () =>
-      branchLanes.length > 0
-        ? `repeat(${branchLanes.length}, ${LANE_COLUMN_WIDTH}px)`
-        : '1fr',
-    [branchLanes.length]
+  const laneColumnTemplate = useMemo(
+    () => (laneCount > 0 ? `repeat(${laneCount}, ${LANE_COLUMN_WIDTH}px)` : ''),
+    [laneCount]
   );
 
   const renderLaneCell = (
     commit: GitCommit,
-    lane: BranchLane,
     laneIndex: number,
     rowIndex: number
   ) => {
     const commitLane = commitLaneMap[commit.id];
-    const isCommitLane = laneIndex === commitLane;
-    const laneState = laneStates[rowIndex]?.[laneIndex];
-    const incoming = laneState?.incoming ?? [];
-    const outgoing = laneState?.outgoing ?? [];
-    const passing = laneState?.passing ?? [];
-
-    const verticalSegments = [
-      ...passing.map((connection) => ({
-        color: connection.color,
-        top: 0,
-        height: '100%'
-      })),
-      ...incoming.map((connection) => ({
-        color: connection.color,
-        top: 0,
-        height: '50%'
-      })),
-      ...outgoing.map((connection) => ({
-        color: connection.color,
-        top: '50%',
-        height: '50%'
-      }))
-    ];
-
-    const getOffset = (index: number, total: number) =>
-      (index - (total - 1) / 2) * LINE_OFFSET;
+    const isCommitLane = commitLane === laneIndex;
+    const branchName = commitBranchMap[commit.id];
+    const commitColor = branchColors[branchName] ?? '#6B7280';
+    const laneColor = laneSegments[rowIndex]?.[laneIndex];
 
     return (
-      <div key={lane.name} className="relative flex items-center justify-center py-6">
-        {verticalSegments.map((segment, index) => {
-          const offset = getOffset(index, verticalSegments.length);
-
-          return (
-            <div
-              key={`segment-${index}`}
-              className="absolute w-1 rounded-full"
-              style={{
-                left: `calc(50% + ${offset}px)`,
-                top: segment.top,
-                height: segment.height,
-                backgroundColor: segment.color,
-                opacity: 0.35
-              }}
-            />
-          );
-        })}
+      <div key={`lane-${laneIndex}`} className="relative flex items-center justify-center py-6">
+        {laneColor && (
+          <div
+            className="absolute top-0 left-1/2 h-full w-1 -translate-x-1/2 rounded-full"
+            style={{
+              backgroundColor: laneColor,
+              opacity: isCommitLane ? 0.6 : 0.25
+            }}
+          />
+        )}
 
         {isCommitLane && (
           <div ref={registerNodeRef(commit.id)} className="relative z-20">
             <CommitNode
               commit={commit}
-              branchColor={lane.color}
+              branchColor={commitColor}
               onClick={() => onCommitClick(commit)}
               onContextMenu={(event) => handleContextMenu(event, commit)}
             />
@@ -391,19 +510,21 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   };
 
   const renderCommitRow = (commit: GitCommit, index: number) => {
+    const gridTemplate =
+      laneCount > 0
+        ? `${laneColumnTemplate} minmax(0, 1fr)`
+        : 'minmax(0, 1fr)';
+
     return (
       <div
         key={commit.id}
         className="grid border-b border-gray-800 bg-gray-900/60 hover:bg-gray-900 transition-colors"
-        style={{ gridTemplateColumns: `${timelineColumns} minmax(0, 1fr)` }}
+        style={{ gridTemplateColumns: gridTemplate }}
       >
-        {branchLanes.length > 0 ? (
-          branchLanes.map((lane, laneIndex) =>
-            renderLaneCell(commit, lane, laneIndex, index)
-          )
-        ) : (
-          <div className="py-6" />
-        )}
+        {laneCount > 0 &&
+          Array.from({ length: laneCount }, (_, laneIndex) =>
+            renderLaneCell(commit, laneIndex, index)
+          )}
 
         <div className="flex flex-col gap-2 py-4 pr-6">
           <div className="flex flex-wrap items-center gap-3">
@@ -417,18 +538,23 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             </button>
 
             <div className="flex flex-wrap items-center gap-2">
-              {commit.branches.map((branch) => (
-                <span
-                  key={`${commit.id}-${branch}`}
-                  className="px-2 py-0.5 text-xs font-medium rounded-full border"
-                  style={{
-                    borderColor: getBranchColor(branch),
-                    color: getBranchColor(branch)
-                  }}
+              {commit.branches.map((branch) => {
+                const normalized = canonicalBranchName(branch);
+                const color = branchColors[normalized] ?? getBranchColor(normalized);
+
+                return (
+                  <span
+                    key={`${commit.id}-${branch}`}
+                    className="px-2 py-0.5 text-xs font-medium rounded-full border"
+                    style={{
+                      borderColor: color,
+                      color
+                    }}
                   >
                     {branch}
                   </span>
-              ))}
+                );
+              })}
 
               {commit.tags.map((tag) => (
                 <span
@@ -448,9 +574,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             <span>
               {commit.date.toLocaleDateString()} {commit.date.toLocaleTimeString()}
             </span>
-            <span className="text-green-400">
-              +{commit.stats.additions}
-            </span>
+            <span className="text-green-400">+{commit.stats.additions}</span>
             <span className="text-red-400">-{commit.stats.deletions}</span>
             <span>{commit.files.length} file{commit.files.length === 1 ? '' : 's'}</span>
           </div>
@@ -471,7 +595,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
           </div>
 
           <div className="space-y-3 px-4 py-4">
-            {branchLanes.map((lane) => (
+            {branchList.map((lane) => (
               <div key={lane.name} className="flex items-center gap-3">
                 <span
                   className="h-3 w-3 rounded-full"
@@ -483,7 +607,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
               </div>
             ))}
 
-            {branchLanes.length === 0 && (
+            {branchList.length === 0 && (
               <div className="text-sm text-gray-500">No branches detected</div>
             )}
           </div>

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { GitCommit, CommitGraphNode } from '../types/git';
+import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import { GitCommit } from '../types/git';
 import { CommitNode } from './CommitNode';
 import { ContextMenu } from './ContextMenu';
-import { Tag, GitBranch } from 'lucide-react';
+import { GitBranch, Tag } from 'lucide-react';
 
 interface CommitGraphProps {
   commits: GitCommit[];
@@ -23,9 +23,35 @@ interface ContextMenuState {
 interface BranchLane {
   name: string;
   color: string;
-  active: boolean;
+  firstCommitIndex: number;
   lastCommitIndex: number;
 }
+
+const LANE_COLUMN_WIDTH = 72;
+
+const getBranchColor = (branchName: string): string => {
+  const predefined: Record<string, string> = {
+    main: '#3B82F6',
+    master: '#3B82F6',
+    develop: '#10B981',
+    feature: '#8B5CF6',
+    hotfix: '#EF4444',
+    release: '#F59E0B'
+  };
+
+  for (const key of Object.keys(predefined)) {
+    if (branchName.includes(key)) {
+      return predefined[key];
+    }
+  }
+
+  let hash = 0;
+  for (let i = 0; i < branchName.length; i += 1) {
+    hash = branchName.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 70%, 60%)`;
+};
 
 export const CommitGraph: React.FC<CommitGraphProps> = ({
   commits,
@@ -35,92 +61,45 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   onRevert,
   onCreateBranch
 }) => {
-  const LANE_SPACING = 56;
-  const VERTICAL_SPACING = 80;
-  const NODE_VERTICAL_OFFSET = 40;
-  const NODE_RADIUS = 20;
-  const CONNECTION_RADIUS = 18;
-
+  const containerRef = useRef<HTMLDivElement>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     show: false,
     x: 0,
     y: 0,
     commit: null
   });
-  
-  const containerRef = useRef<HTMLDivElement>(null);
 
-  
+  const sortedCommits = useMemo(
+    () => [...commits].sort((a, b) => b.date.getTime() - a.date.getTime()),
+    [commits]
+  );
 
-  const getBranchColor = (branchName: string): string => {
-    const colors = {
-      'main': '#3B82F6',
-      'master': '#3B82F6',
-      'develop': '#10B981',
-      'feature': '#8B5CF6',
-      'hotfix': '#EF4444',
-      'release': '#F59E0B'
-    };
-    
-    for (const [key, color] of Object.entries(colors)) {
-      if (branchName.includes(key)) return color;
-    }
-    
-    // Generate consistent color based on branch name
-    let hash = 0;
-    for (let i = 0; i < branchName.length; i++) {
-      hash = branchName.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    const hue = Math.abs(hash) % 360;
-    return `hsl(${hue}, 70%, 60%)`;
-  };
-  // Generate graph layout with proper branch lanes
-  const { graphNodes, branchLanes } = React.useMemo(() => {
+  const { branchLanes, commitLaneMap } = useMemo(() => {
     const lanes: BranchLane[] = [];
-    const nodes: CommitGraphNode[] = [];
-    const commitToLane: { [commitId: string]: number } = {};
-    
-    // Sort commits by date (newest first)
-    const sortedCommits = [...commits].sort((a, b) => b.date.getTime() - a.date.getTime());
-    
+    const laneIndexByName: Record<string, number> = {};
+    const laneMap: Record<string, number> = {};
+
     sortedCommits.forEach((commit, index) => {
-      const primaryBranch = commit.branches[0] || 'main';
+      const primaryBranch = commit.branches[0] || 'detached';
 
-      // Find existing lane for this branch or create new one
-      let laneIndex = lanes.findIndex(lane => lane.name === primaryBranch);
-
-      if (laneIndex === -1) {
-        // Create new lane
-        laneIndex = lanes.length;
+      if (laneIndexByName[primaryBranch] === undefined) {
+        laneIndexByName[primaryBranch] = lanes.length;
         lanes.push({
           name: primaryBranch,
           color: getBranchColor(primaryBranch),
-          active: true,
+          firstCommitIndex: index,
           lastCommitIndex: index
         });
       } else {
-        // Update existing lane
-        lanes[laneIndex].lastCommitIndex = index;
+        const lane = lanes[laneIndexByName[primaryBranch]];
+        lane.lastCommitIndex = Math.max(lane.lastCommitIndex, index);
       }
-      
-      commitToLane[commit.id] = laneIndex;
-      
-      const node: CommitGraphNode = {
-        commit,
-        x: laneIndex * LANE_SPACING + LANE_SPACING / 2,
-        y: index * VERTICAL_SPACING + NODE_VERTICAL_OFFSET,
-        lane: laneIndex,
-        connections: commit.parents.map(parentId => ({
-          to: parentId,
-          type: commit.parents.length > 1 ? 'merge' : 'parent'
-        }))
-      };
-      
-      nodes.push(node);
+
+      laneMap[commit.id] = laneIndexByName[primaryBranch];
     });
-    
-    return { graphNodes: nodes, branchLanes: lanes };
-  }, [commits]);
+
+    return { branchLanes: lanes, commitLaneMap: laneMap };
+  }, [sortedCommits]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent, commit: GitCommit) => {
     e.preventDefault();
@@ -136,278 +115,217 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     setContextMenu({ show: false, x: 0, y: 0, commit: null });
   }, []);
 
-  const renderConnections = () => {
-    const connections: React.ReactElement[] = [];
-    
-    graphNodes.forEach((node) => {
-      node.connections.forEach((connection) => {
-        const targetNode = graphNodes.find(n => n.commit.id === connection.to);
-        if (!targetNode) return;
-        
-        const startX = node.x;
-        const startY = node.y;
-        const endX = targetNode.x;
-        const endY = targetNode.y;
-
-        const color = getBranchColor(node.commit.branches[0] || 'main');
-        const strokeWidth = connection.type === 'merge' ? 3 : 2;
-        const opacity = connection.type === 'merge' ? 0.8 : 0.6;
-
-        if (startX === endX) {
-          // Straight line for same lane
-          connections.push(
-            <line
-              key={`${node.commit.id}-${connection.to}`}
-              x1={startX}
-              y1={startY + NODE_RADIUS}
-              x2={endX}
-              y2={endY - NODE_RADIUS}
-              stroke={color}
-              strokeWidth={strokeWidth}
-              opacity={opacity}
-              className="transition-all duration-200"
-            />
-          );
-        } else {
-          // 90-degree styled connection for different lanes
-          const startYAdjusted = startY + NODE_RADIUS;
-          const endYAdjusted = endY - NODE_RADIUS;
-          const verticalDirection = endYAdjusted >= startYAdjusted ? 1 : -1;
-          const horizontalDirection = endX > startX ? 1 : -1;
-          const horizontalDistance = Math.abs(endX - startX);
-          const verticalDistance = Math.abs(endYAdjusted - startYAdjusted);
-
-          const maxVerticalCorner = Math.max(verticalDistance / 2 - 4, 0);
-          let cornerRadius = Math.min(
-            CONNECTION_RADIUS,
-            horizontalDistance / 2,
-            maxVerticalCorner
-          );
-
-          if (cornerRadius < 6 && maxVerticalCorner >= 6) {
-            cornerRadius = Math.min(6, horizontalDistance / 2);
-          }
-
-          if (cornerRadius <= 0) {
-            const midY = (startYAdjusted + endYAdjusted) / 2;
-            const path = [
-              `M ${startX} ${startYAdjusted}`,
-              `L ${startX} ${midY}`,
-              `L ${endX} ${midY}`,
-              `L ${endX} ${endYAdjusted}`
-            ].join(' ');
-
-            connections.push(
-              <path
-                key={`${node.commit.id}-${connection.to}`}
-                d={path}
-                stroke={color}
-                strokeWidth={strokeWidth}
-                opacity={opacity}
-                fill="none"
-                className="transition-all duration-200"
-              />
-            );
-            return;
-          }
-
-          const midY = (startYAdjusted + endYAdjusted) / 2;
-          const firstCornerY = midY - verticalDirection * cornerRadius;
-          const secondCornerY = midY + verticalDirection * cornerRadius;
-          const firstCornerX = startX + horizontalDirection * cornerRadius;
-          const secondCornerX = endX - horizontalDirection * cornerRadius;
-
-          const path = [
-            `M ${startX} ${startYAdjusted}`,
-            `L ${startX} ${firstCornerY}`,
-            `Q ${startX} ${midY} ${firstCornerX} ${midY}`,
-            `L ${secondCornerX} ${midY}`,
-            `Q ${endX} ${midY} ${endX} ${secondCornerY}`,
-            `L ${endX} ${endYAdjusted}`
-          ].join(' ');
-
-          connections.push(
-            <path
-              key={`${node.commit.id}-${connection.to}`}
-              d={path}
-              stroke={color}
-              strokeWidth={strokeWidth}
-              opacity={opacity}
-              fill="none"
-              className="transition-all duration-200"
-            />
-          );
-        }
-      });
-    });
-    
-    return connections;
-  };
-
-  const renderBranchLanes = () => {
-    return branchLanes.map((lane, index) => (
-      <div
-        key={lane.name}
-        className="absolute top-0 bottom-0 flex flex-col items-center"
-        style={{ left: index * LANE_SPACING + LANE_SPACING / 2, width: LANE_SPACING }}
-      >
-        {/* Branch line */}
-        <div
-          className="w-0.5 h-full opacity-30"
-          style={{ backgroundColor: lane.color }}
-        />
-      </div>
-    ));
-  };
-
   useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (contextMenu.show && containerRef.current && !containerRef.current.contains(e.target as Node)) {
+    const handleGlobalClick = (event: MouseEvent) => {
+      if (
+        contextMenu.show &&
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
         handleCloseContextMenu();
       }
     };
-    
-    document.addEventListener('click', handleClick);
-    return () => document.removeEventListener('click', handleClick);
+
+    document.addEventListener('click', handleGlobalClick);
+    return () => document.removeEventListener('click', handleGlobalClick);
   }, [contextMenu.show, handleCloseContextMenu]);
 
-  const maxNodeX = graphNodes.length > 0 ? Math.max(...graphNodes.map(n => n.x)) : 0;
-  const maxNodeY = graphNodes.length > 0 ? Math.max(...graphNodes.map(n => n.y)) : 0;
-  const maxX = maxNodeX + 200;
-  const maxY = maxNodeY + 100;
-  const branchColumnWidth = 200;
+  const timelineColumns = useMemo(
+    () =>
+      branchLanes.length > 0
+        ? `repeat(${branchLanes.length}, ${LANE_COLUMN_WIDTH}px)`
+        : '1fr',
+    [branchLanes.length]
+  );
+
+  const renderLaneCell = (
+    commit: GitCommit,
+    lane: BranchLane,
+    laneIndex: number,
+    rowIndex: number
+  ) => {
+    const commitLane = commitLaneMap[commit.id];
+    const isCommitLane = laneIndex === commitLane;
+    const parentLanes = commit.parents
+      .map((parentId) => commitLaneMap[parentId])
+      .filter((value): value is number => value !== undefined);
+
+    const isParentLane = parentLanes.includes(laneIndex) && !isCommitLane;
+    const showTopConnector = isCommitLane && rowIndex > lane.firstCommitIndex;
+    const showBottomConnector = isCommitLane && rowIndex < lane.lastCommitIndex;
+    const showPassingLine =
+      !isCommitLane &&
+      rowIndex > lane.firstCommitIndex &&
+      rowIndex < lane.lastCommitIndex;
+
+    return (
+      <div key={lane.name} className="relative flex items-center justify-center py-6">
+        {showPassingLine && (
+          <div
+            className="absolute top-0 bottom-0 w-0.5 opacity-40"
+            style={{ backgroundColor: lane.color }}
+          />
+        )}
+
+        {showTopConnector && (
+          <div
+            className="absolute top-0 left-1/2 w-0.5 opacity-60"
+            style={{
+              backgroundColor: lane.color,
+              transform: 'translateX(-50%)',
+              height: '50%'
+            }}
+          />
+        )}
+
+        {showBottomConnector && (
+          <div
+            className="absolute bottom-0 left-1/2 w-0.5 opacity-60"
+            style={{
+              backgroundColor: lane.color,
+              transform: 'translateX(-50%)',
+              height: '50%'
+            }}
+          />
+        )}
+
+        {isParentLane && (
+          <div
+            className="w-3 h-3 rounded-full border-2"
+            style={{ borderColor: lane.color }}
+          />
+        )}
+
+        {isCommitLane && (
+          <CommitNode
+            commit={commit}
+            branchColor={lane.color}
+            onClick={() => onCommitClick(commit)}
+            onContextMenu={(event) => handleContextMenu(event, commit)}
+          />
+        )}
+      </div>
+    );
+  };
+
+  const renderCommitRow = (commit: GitCommit, index: number) => {
+    return (
+      <div
+        key={commit.id}
+        className="grid border-b border-gray-800 bg-gray-900/60 hover:bg-gray-900 transition-colors"
+        style={{ gridTemplateColumns: `${timelineColumns} minmax(0, 1fr)` }}
+      >
+        {branchLanes.length > 0 ? (
+          branchLanes.map((lane, laneIndex) =>
+            renderLaneCell(commit, lane, laneIndex, index)
+          )
+        ) : (
+          <div className="py-6" />
+        )}
+
+        <div className="flex flex-col gap-2 py-4 pr-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => onCommitClick(commit)}
+              onContextMenu={(event) => handleContextMenu(event, commit)}
+              className="text-left text-sm font-semibold text-gray-100 hover:text-white"
+            >
+              {commit.message}
+            </button>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {commit.branches.map((branch) => (
+                <span
+                  key={`${commit.id}-${branch}`}
+                  className="px-2 py-0.5 text-xs font-medium rounded-full border"
+                  style={{
+                    borderColor: getBranchColor(branch),
+                    color: getBranchColor(branch)
+                  }}
+                  >
+                    {branch}
+                  </span>
+              ))}
+
+              {commit.tags.map((tag) => (
+                <span
+                  key={`${commit.id}-${tag}`}
+                  className="inline-flex items-center gap-1 rounded-full bg-yellow-600/20 px-2 py-0.5 text-xs font-medium text-yellow-200"
+                >
+                  <Tag className="h-3 w-3" />
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-400">
+            <span className="font-mono text-gray-300">{commit.shortHash}</span>
+            <span>{commit.author.name}</span>
+            <span>
+              {commit.date.toLocaleDateString()} {commit.date.toLocaleTimeString()}
+            </span>
+            <span className="text-green-400">
+              +{commit.stats.additions}
+            </span>
+            <span className="text-red-400">-{commit.stats.deletions}</span>
+            <span>{commit.files.length} file{commit.files.length === 1 ? '' : 's'}</span>
+          </div>
+        </div>
+      </div>
+    );
+  };
 
   return (
-    <div className="flex-1 bg-gray-900 overflow-auto relative flex" ref={containerRef}>
-      {/* Branch Column */}
-      <div 
-        className="bg-gray-800 border-r border-gray-700 flex-shrink-0 overflow-hidden"
-        style={{ width: branchColumnWidth }}
-      >
-        <div className="p-4 border-b border-gray-700">
-          <h3 className="text-sm font-medium text-gray-300 flex items-center">
-            <GitBranch className="w-4 h-4 mr-2" />
-            Branches
-          </h3>
+    <div className="flex-1 bg-gray-900 text-gray-100" ref={containerRef}>
+      <div className="flex h-full overflow-auto">
+        <div className="w-56 flex-shrink-0 border-r border-gray-800 bg-gray-900/80">
+          <div className="border-b border-gray-800 px-4 py-3">
+            <h3 className="flex items-center text-sm font-medium text-gray-300">
+              <GitBranch className="mr-2 h-4 w-4" />
+              Branches
+            </h3>
+          </div>
+
+          <div className="space-y-3 px-4 py-4">
+            {branchLanes.map((lane) => (
+              <div key={lane.name} className="flex items-center gap-3">
+                <span
+                  className="h-3 w-3 rounded-full"
+                  style={{ backgroundColor: lane.color }}
+                />
+                <span className="truncate text-sm font-medium" style={{ color: lane.color }}>
+                  {lane.name}
+                </span>
+              </div>
+            ))}
+
+            {branchLanes.length === 0 && (
+              <div className="text-sm text-gray-500">No branches detected</div>
+            )}
+          </div>
         </div>
-        
-        <div className="relative" style={{ height: maxY }}>
-          {branchLanes.map((lane, index) => (
-            <div
-              key={lane.name}
-              className="absolute flex items-center px-4 py-2"
-              style={{
-                top: NODE_VERTICAL_OFFSET,
-                left: 0,
-                right: 0,
-                transform: `translateY(${index * VERTICAL_SPACING}px)`
-              }}
-            >
-              <div
-                className="w-3 h-3 rounded-full mr-3 flex-shrink-0"
-                style={{ backgroundColor: lane.color }}
-              />
-              <span 
-                className="text-sm font-medium truncate"
-                style={{ color: lane.color }}
-                title={lane.name}
-              >
-                {lane.name}
-              </span>
-            </div>
-          ))}
+
+        <div className="flex-1 overflow-auto">
+          <div className="min-w-full divide-y divide-gray-800">
+            {sortedCommits.map((commit, index) => renderCommitRow(commit, index))}
+          </div>
         </div>
       </div>
 
-      {/* Graph Area */}
-      <div className="flex-1 relative">
-        <div 
-          className="relative"
-          style={{ 
-            width: Math.max(maxX - branchColumnWidth, 600), 
-            height: Math.max(maxY, 600),
-            minWidth: '100%'
-          }}
-        >
-          {/* Branch lane lines */}
-          {renderBranchLanes()}
-          
-          {/* Connection lines */}
-          <svg
-            width={maxX - branchColumnWidth}
-            height={maxY}
-            className="absolute inset-0"
-            style={{ pointerEvents: 'none' }}
-          >
-            <defs>
-              <filter id="glow">
-                <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
-                <feMerge> 
-                  <feMergeNode in="coloredBlur"/>
-                  <feMergeNode in="SourceGraphic"/>
-                </feMerge>
-              </filter>
-            </defs>
-            {renderConnections()}
-          </svg>
-          
-          {/* Commit nodes */}
-          {graphNodes.map((node) => (
-            <div
-              key={node.commit.id}
-              className="absolute transform -translate-x-1/2 -translate-y-1/2"
-              style={{ left: node.x, top: node.y }}
-            >
-              <CommitNode
-                commit={node.commit}
-                branchColor={getBranchColor(node.commit.branches[0] || 'main')}
-                onClick={() => onCommitClick(node.commit)}
-                onContextMenu={(e) => handleContextMenu(e, node.commit)}
-              />
-              
-              {/* Tags */}
-              {node.commit.tags.map((tag, idx) => (
-                <div
-                  key={tag}
-                  className="absolute -top-8 left-full ml-4 bg-yellow-600 text-yellow-100 px-2 py-1 rounded text-xs font-medium flex items-center whitespace-nowrap z-10"
-                  style={{ transform: `translateY(${idx * -24}px)` }}
-                >
-                  <Tag className="w-3 h-3 mr-1" />
-                  {tag}
-                </div>
-              ))}
-              
-              {/* Commit message */}
-              <div
-                className="absolute left-full ml-4 top-1/2 transform -translate-y-1/2 text-sm text-gray-300 whitespace-nowrap max-w-md truncate"
-                title={node.commit.message}
-              >
-                {node.commit.message}
-              </div>
-              
-              {/* Commit metadata */}
-              <div className="absolute left-full ml-4 top-1/2 transform -translate-y-1/2 translate-y-4 text-xs text-gray-500 whitespace-nowrap">
-                <span className="font-mono mr-2">{node.commit.shortHash}</span>
-                <span className="mr-2">{node.commit.author.name}</span>
-                <span>{node.commit.date.toLocaleDateString()}</span>
-              </div>
-            </div>
-          ))}
-          
-          {contextMenu.show && contextMenu.commit && (
-            <ContextMenu
-              x={contextMenu.x - branchColumnWidth}
-              y={contextMenu.y}
-              commit={contextMenu.commit}
-              onReset={onReset}
-              onCherryPick={onCherryPick}
-              onRevert={onRevert}
-              onCreateBranch={onCreateBranch}
-              onClose={handleCloseContextMenu}
-            />
-          )}
-        </div>
-      </div>
+      {contextMenu.show && contextMenu.commit && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          commit={contextMenu.commit}
+          onReset={onReset}
+          onCherryPick={onCherryPick}
+          onRevert={onRevert}
+          onCreateBranch={onCreateBranch}
+          onClose={handleCloseContextMenu}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -51,10 +51,7 @@ interface LaneConnectionState {
 
 interface ConnectionLine {
   id: string;
-  x1: number;
-  y1: number;
-  x2: number;
-  y2: number;
+  path: string;
   color: string;
 }
 
@@ -237,12 +234,14 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
       const x2 = toElement.offsetLeft + toElement.offsetWidth / 2;
       const y2 = toElement.offsetTop + toElement.offsetHeight / 2;
 
+      const sameLane = Math.abs(x1 - x2) < 1;
+      const path = sameLane
+        ? `M ${x1} ${y1} L ${x2} ${y2}`
+        : `M ${x1} ${y1} V ${y2} H ${x2}`;
+
       lines.push({
         id: connection.id,
-        x1,
-        y1,
-        x2,
-        y2,
+        path,
         color: connection.color
       });
     });
@@ -503,15 +502,14 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                 viewBox={`0 0 ${graphDimensions.width} ${graphDimensions.height}`}
               >
                 {connectionLines.map((line) => (
-                  <line
+                  <path
                     key={line.id}
-                    x1={line.x1}
-                    y1={line.y1}
-                    x2={line.x2}
-                    y2={line.y2}
+                    d={line.path}
                     stroke={line.color}
                     strokeWidth={4}
                     strokeLinecap="round"
+                    strokeLinejoin="round"
+                    fill="none"
                     opacity={0.45}
                   />
                 ))}

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -192,28 +192,59 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   // SVG connection lines
   const svgConnections = useMemo(() => {
     const lines: { id: string; path: string; color: string }[] = [];
+    // Draw vertical lines for each lane (continuous)
+    branchLanes.forEach((lane, laneIndex) => {
+      let prevY: number | null = null;
+      sortedCommits.forEach((commit, rowIndex) => {
+        if (commitLaneMap[commit.id] === laneIndex) {
+          const pos = nodePositions[commit.id];
+          if (prevY !== null) {
+            lines.push({
+              id: `lane-${lane.name}-v-${rowIndex}`,
+              path: `M ${pos.x} ${prevY} L ${pos.x} ${pos.y}`,
+              color: lane.color
+            });
+          }
+          prevY = pos.y;
+        }
+      });
+    });
+    // Draw connections (forks and merges)
     connections.forEach((connection) => {
       const fromPos = nodePositions[sortedCommits[connection.fromIndex].id];
       const toPos = nodePositions[sortedCommits[connection.toIndex].id];
       if (!fromPos || !toPos) return;
-      if (fromPos.lane === toPos.lane) {
-        // Vertical line
+      const isBranchStart = branchLanes[toPos.lane]?.firstCommitIndex === connection.toIndex && fromPos.lane !== toPos.lane;
+      if (isBranchStart) {
+        // Branch start: fork at parent node's Y position
         lines.push({
-          id: connection.id,
-          path: `M ${fromPos.x} ${fromPos.y} L ${toPos.x} ${toPos.y}`,
+          id: connection.id + '-branch-h',
+          path: `M ${fromPos.x} ${fromPos.y} H ${toPos.x}`,
           color: connection.color
         });
-      } else {
-        // Merge: horizontal from parent to child lane, then vertical down
         lines.push({
-          id: connection.id + '-h',
-          path: `M ${fromPos.x} ${fromPos.y} H ${toPos.x} V ${toPos.y}`,
+          id: connection.id + '-branch-v',
+          path: `M ${toPos.x} ${fromPos.y} V ${toPos.y}`,
+          color: connection.color
+        });
+      } else if (fromPos.lane === toPos.lane) {
+        // Already handled by vertical lane lines above
+      } else {
+        // Merge: horizontal at child Y, then vertical up to parent
+        lines.push({
+          id: connection.id + '-merge-h',
+          path: `M ${fromPos.x} ${toPos.y} H ${toPos.x}`,
+          color: connection.color
+        });
+        lines.push({
+          id: connection.id + '-merge-v',
+          path: `M ${fromPos.x} ${fromPos.y} V ${toPos.y}`,
           color: connection.color
         });
       }
     });
     return lines;
-  }, [connections, nodePositions, sortedCommits]);
+  }, [connections, nodePositions, sortedCommits, branchLanes, commitLaneMap]);
 
   const registerNodeRef = useCallback(
     (commitId: string) => (element: HTMLDivElement | null) => {

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -1,4 +1,11 @@
-import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import React, {
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useLayoutEffect
+} from 'react';
 import { GitCommit } from '../types/git';
 import { CommitNode } from './CommitNode';
 import { ContextMenu } from './ContextMenu';
@@ -27,7 +34,32 @@ interface BranchLane {
   lastCommitIndex: number;
 }
 
+interface GraphConnection {
+  id: string;
+  fromIndex: number;
+  toIndex: number;
+  fromLane: number;
+  toLane: number;
+  color: string;
+}
+
+interface LaneConnectionState {
+  incoming: GraphConnection[];
+  outgoing: GraphConnection[];
+  passing: GraphConnection[];
+}
+
+interface ConnectionLine {
+  id: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  color: string;
+}
+
 const LANE_COLUMN_WIDTH = 72;
+const LINE_OFFSET = 6;
 
 const getBranchColor = (branchName: string): string => {
   const predefined: Record<string, string> = {
@@ -62,25 +94,31 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   onCreateBranch
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const nodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     show: false,
     x: 0,
     y: 0,
     commit: null
   });
+  const [connectionLines, setConnectionLines] = useState<ConnectionLine[]>([]);
+  const [graphDimensions, setGraphDimensions] = useState({ width: 0, height: 0 });
 
   const sortedCommits = useMemo(
     () => [...commits].sort((a, b) => b.date.getTime() - a.date.getTime()),
     [commits]
   );
 
-  const { branchLanes, commitLaneMap } = useMemo(() => {
+  const { branchLanes, commitLaneMap, laneStates, connections } = useMemo(() => {
     const lanes: BranchLane[] = [];
     const laneIndexByName: Record<string, number> = {};
     const laneMap: Record<string, number> = {};
+    const commitIndexMap: Record<string, number> = {};
 
     sortedCommits.forEach((commit, index) => {
       const primaryBranch = commit.branches[0] || 'detached';
+      commitIndexMap[commit.id] = index;
 
       if (laneIndexByName[primaryBranch] === undefined) {
         laneIndexByName[primaryBranch] = lanes.length;
@@ -98,8 +136,155 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
       laneMap[commit.id] = laneIndexByName[primaryBranch];
     });
 
-    return { branchLanes: lanes, commitLaneMap: laneMap };
+    const connectionStates: LaneConnectionState[][] = sortedCommits.map(() =>
+      lanes.map(() => ({ incoming: [], outgoing: [], passing: [] }))
+    );
+
+    const connections: GraphConnection[] = [];
+
+    sortedCommits.forEach((commit, fromIndex) => {
+      const fromLane = laneMap[commit.id];
+
+      if (fromLane === undefined) {
+        return;
+      }
+
+      commit.parents.forEach((parentId) => {
+        const toIndex = commitIndexMap[parentId];
+
+        if (toIndex === undefined) {
+          return;
+        }
+
+        const toLane = laneMap[parentId] ?? fromLane;
+        const color = lanes[fromLane]?.color ?? '#6B7280';
+        const connection: GraphConnection = {
+          id: `${commit.id}-${parentId}`,
+          fromIndex,
+          toIndex,
+          fromLane,
+          toLane,
+          color
+        };
+
+        connections.push(connection);
+      });
+    });
+
+    connections.forEach((connection) => {
+      const { fromIndex, toIndex, fromLane, toLane } = connection;
+
+      const fromLaneState = connectionStates[fromIndex]?.[fromLane];
+      const toLaneState = connectionStates[toIndex]?.[toLane];
+
+      fromLaneState?.outgoing.push(connection);
+
+      for (let row = fromIndex + 1; row < toIndex; row += 1) {
+        const passingLaneState = connectionStates[row]?.[fromLane];
+        passingLaneState?.passing.push(connection);
+      }
+
+      toLaneState?.incoming.push(connection);
+    });
+
+    return {
+      branchLanes: lanes,
+      commitLaneMap: laneMap,
+      laneStates: connectionStates,
+      connections
+    };
   }, [sortedCommits]);
+
+  const registerNodeRef = useCallback(
+    (commitId: string) => (element: HTMLDivElement | null) => {
+      if (element) {
+        nodeRefs.current[commitId] = element;
+      } else {
+        delete nodeRefs.current[commitId];
+      }
+    },
+    []
+  );
+
+  const recomputeConnections = useCallback(() => {
+    const container = timelineRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    const width = container.scrollWidth;
+    const height = container.scrollHeight;
+    const lines: ConnectionLine[] = [];
+
+    connections.forEach((connection) => {
+      const fromCommit = sortedCommits[connection.fromIndex];
+      const toCommit = sortedCommits[connection.toIndex];
+
+      if (!fromCommit || !toCommit) {
+        return;
+      }
+
+      const fromElement = nodeRefs.current[fromCommit.id];
+      const toElement = nodeRefs.current[toCommit.id];
+
+      if (!fromElement || !toElement) {
+        return;
+      }
+
+      const x1 = fromElement.offsetLeft + fromElement.offsetWidth / 2;
+      const y1 = fromElement.offsetTop + fromElement.offsetHeight / 2;
+      const x2 = toElement.offsetLeft + toElement.offsetWidth / 2;
+      const y2 = toElement.offsetTop + toElement.offsetHeight / 2;
+
+      lines.push({
+        id: connection.id,
+        x1,
+        y1,
+        x2,
+        y2,
+        color: connection.color
+      });
+    });
+
+    setGraphDimensions({ width, height });
+    setConnectionLines(lines);
+  }, [connections, sortedCommits]);
+
+  useLayoutEffect(() => {
+    recomputeConnections();
+  }, [recomputeConnections]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      recomputeConnections();
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [recomputeConnections]);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const container = timelineRef.current;
+
+    if (!container) {
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(() => {
+      recomputeConnections();
+    });
+
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [recomputeConnections]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent, commit: GitCommit) => {
     e.preventDefault();
@@ -146,63 +331,61 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   ) => {
     const commitLane = commitLaneMap[commit.id];
     const isCommitLane = laneIndex === commitLane;
-    const parentLanes = commit.parents
-      .map((parentId) => commitLaneMap[parentId])
-      .filter((value): value is number => value !== undefined);
+    const laneState = laneStates[rowIndex]?.[laneIndex];
+    const incoming = laneState?.incoming ?? [];
+    const outgoing = laneState?.outgoing ?? [];
+    const passing = laneState?.passing ?? [];
 
-    const isParentLane = parentLanes.includes(laneIndex) && !isCommitLane;
-    const showTopConnector = isCommitLane && rowIndex > lane.firstCommitIndex;
-    const showBottomConnector = isCommitLane && rowIndex < lane.lastCommitIndex;
-    const showPassingLine =
-      !isCommitLane &&
-      rowIndex > lane.firstCommitIndex &&
-      rowIndex < lane.lastCommitIndex;
+    const verticalSegments = [
+      ...passing.map((connection) => ({
+        color: connection.color,
+        top: 0,
+        height: '100%'
+      })),
+      ...incoming.map((connection) => ({
+        color: connection.color,
+        top: 0,
+        height: '50%'
+      })),
+      ...outgoing.map((connection) => ({
+        color: connection.color,
+        top: '50%',
+        height: '50%'
+      }))
+    ];
+
+    const getOffset = (index: number, total: number) =>
+      (index - (total - 1) / 2) * LINE_OFFSET;
 
     return (
       <div key={lane.name} className="relative flex items-center justify-center py-6">
-        {showPassingLine && (
-          <div
-            className="absolute top-0 bottom-0 w-0.5 opacity-40"
-            style={{ backgroundColor: lane.color }}
-          />
-        )}
+        {verticalSegments.map((segment, index) => {
+          const offset = getOffset(index, verticalSegments.length);
 
-        {showTopConnector && (
-          <div
-            className="absolute top-0 left-1/2 w-0.5 opacity-60"
-            style={{
-              backgroundColor: lane.color,
-              transform: 'translateX(-50%)',
-              height: '50%'
-            }}
-          />
-        )}
-
-        {showBottomConnector && (
-          <div
-            className="absolute bottom-0 left-1/2 w-0.5 opacity-60"
-            style={{
-              backgroundColor: lane.color,
-              transform: 'translateX(-50%)',
-              height: '50%'
-            }}
-          />
-        )}
-
-        {isParentLane && (
-          <div
-            className="w-3 h-3 rounded-full border-2"
-            style={{ borderColor: lane.color }}
-          />
-        )}
+          return (
+            <div
+              key={`segment-${index}`}
+              className="absolute w-1 rounded-full"
+              style={{
+                left: `calc(50% + ${offset}px)`,
+                top: segment.top,
+                height: segment.height,
+                backgroundColor: segment.color,
+                opacity: 0.35
+              }}
+            />
+          );
+        })}
 
         {isCommitLane && (
-          <CommitNode
-            commit={commit}
-            branchColor={lane.color}
-            onClick={() => onCommitClick(commit)}
-            onContextMenu={(event) => handleContextMenu(event, commit)}
-          />
+          <div ref={registerNodeRef(commit.id)} className="relative z-20">
+            <CommitNode
+              commit={commit}
+              branchColor={lane.color}
+              onClick={() => onCommitClick(commit)}
+              onContextMenu={(event) => handleContextMenu(event, commit)}
+            />
+          </div>
         )}
       </div>
     );
@@ -308,7 +491,32 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
         </div>
 
         <div className="flex-1 overflow-auto">
-          <div className="min-w-full divide-y divide-gray-800">
+          <div
+            ref={timelineRef}
+            className="relative min-w-full divide-y divide-gray-800"
+          >
+            {graphDimensions.width > 0 && graphDimensions.height > 0 && (
+              <svg
+                className="pointer-events-none absolute inset-0 z-10"
+                width={graphDimensions.width}
+                height={graphDimensions.height}
+                viewBox={`0 0 ${graphDimensions.width} ${graphDimensions.height}`}
+              >
+                {connectionLines.map((line) => (
+                  <line
+                    key={line.id}
+                    x1={line.x1}
+                    y1={line.y1}
+                    x2={line.x2}
+                    y2={line.y2}
+                    stroke={line.color}
+                    strokeWidth={4}
+                    strokeLinecap="round"
+                    opacity={0.45}
+                  />
+                ))}
+              </svg>
+            )}
             {sortedCommits.map((commit, index) => renderCommitRow(commit, index))}
           </div>
         </div>

--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -190,6 +190,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   }, [sortedCommits, commitLaneMap]);
 
   // SVG connection lines
+  const CORNER_RADIUS = 10;
   const svgConnections = useMemo(() => {
     const lines: { id: string; path: string; color: string }[] = [];
     // Draw vertical lines for each lane (continuous)
@@ -209,36 +210,72 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
         }
       });
     });
-    // Draw connections (forks and merges)
+    // Draw connections (forks and merges) with 90-degree turns and rounded corners (outside)
     connections.forEach((connection) => {
       const fromPos = nodePositions[sortedCommits[connection.fromIndex].id];
       const toPos = nodePositions[sortedCommits[connection.toIndex].id];
       if (!fromPos || !toPos) return;
       const isBranchStart = branchLanes[toPos.lane]?.firstCommitIndex === connection.toIndex && fromPos.lane !== toPos.lane;
       if (isBranchStart) {
-        // Branch start: fork at parent node's Y position
+        // Branch start: fork at parent node's Y position, 90-degree turn with rounded corner (outside)
+        const horizontalDir = Math.sign(toPos.x - fromPos.x);
+        const verticalDir = Math.sign(toPos.y - fromPos.y);
+        const cornerX = toPos.x;
+        const cornerY = fromPos.y;
+        // Move horizontally, stop CORNER_RADIUS before the turn
+        const hStopX = cornerX - horizontalDir * CORNER_RADIUS;
+        // Move vertically, start CORNER_RADIUS after the turn
+        const vStartY = cornerY + verticalDir * CORNER_RADIUS;
+        // Sweep flag: 1 if both directions are the same (right-down, left-up), else 0
+        const arcSweep = (horizontalDir === 1 && verticalDir === 1) || (horizontalDir === -1 && verticalDir === -1) ? 1 : 0;
         lines.push({
           id: connection.id + '-branch-h',
-          path: `M ${fromPos.x} ${fromPos.y} H ${toPos.x}`,
+          path: `M ${fromPos.x} ${fromPos.y} H ${hStopX}`,
           color: connection.color
         });
+
+        // Arc for the outside corner
+        lines.push({
+          id: connection.id + '-branch-arc',
+          path: `M ${hStopX} ${cornerY} A ${CORNER_RADIUS} ${CORNER_RADIUS} 0 0 ${arcSweep} ${cornerX} ${vStartY}`,
+          color: connection.color
+        });
+        // Vertical segment
         lines.push({
           id: connection.id + '-branch-v',
-          path: `M ${toPos.x} ${fromPos.y} V ${toPos.y}`,
+          path: `M ${cornerX} ${vStartY} V ${toPos.y}`,
           color: connection.color
         });
       } else if (fromPos.lane === toPos.lane) {
         // Already handled by vertical lane lines above
       } else {
-        // Merge: horizontal at child Y, then vertical up to parent
-        lines.push({
-          id: connection.id + '-merge-h',
-          path: `M ${fromPos.x} ${toPos.y} H ${toPos.x}`,
-          color: connection.color
-        });
+        // Merge: 90-degree turn at child Y with rounded corner (outside)
+        const horizontalDir = Math.sign(toPos.x - fromPos.x);
+        const verticalDir = Math.sign(toPos.y - fromPos.y);
+        const cornerX = toPos.x;
+        const cornerY = toPos.y;
+        // Move vertically, stop CORNER_RADIUS before the turn
+        const vStopY = cornerY - verticalDir * CORNER_RADIUS;
+        // Move horizontally, start CORNER_RADIUS after the turn
+        const hStartX = fromPos.x + horizontalDir * CORNER_RADIUS;
+        // Sweep flag: 1 for right-down, left-up; 0 for right-up, left-down
+        // For outside arc, sweep = (horizontalDir !== verticalDir ? 1 : 0)
+        const arcSweep = horizontalDir !== verticalDir ? 1 : 0;
         lines.push({
           id: connection.id + '-merge-v',
-          path: `M ${fromPos.x} ${fromPos.y} V ${toPos.y}`,
+          path: `M ${fromPos.x} ${fromPos.y} V ${vStopY}`,
+          color: connection.color
+        });
+        // Arc for the outside corner
+        lines.push({
+          id: connection.id + '-merge-arc',
+          path: `M ${fromPos.x} ${vStopY} A ${CORNER_RADIUS} ${CORNER_RADIUS} 0 0 ${arcSweep} ${hStartX} ${cornerY}`,
+          color: connection.color
+        });
+        // Horizontal segment
+        lines.push({
+          id: connection.id + '-merge-h',
+          path: `M ${hStartX} ${cornerY} H ${cornerX}`,
           color: connection.color
         });
       }
@@ -366,7 +403,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   fill="none"
-                  opacity={0.7}
+                  opacity={1}
                 />
               ))}
             </svg>


### PR DESCRIPTION
## Summary
- replace the SVG-heavy commit graph with a simplified grid of rows and branch lanes
- render branch timelines using flex/grid blocks and show commit metadata beside each node
- keep context menu support while streamlining the branch list sidebar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d58330d6c88328b05f51d1d41b2865