### PR TITLE
Shift active lanes to keep branch connectors gap-free

### DIFF
--- a/src/components/CommitGraph.tsx
+++ b/src/components/CommitGraph.tsx
@@ -21,13 +21,6 @@ interface ContextMenuState {
   commit: GitCommit | null;
 }
 
-interface BranchLane {
-  name: string;
-  color: string;
-  firstCommitIndex: number;
-  lastCommitIndex: number;
-}
-
 interface GraphConnection {
   id: string;
   fromIndex: number;
@@ -35,15 +28,21 @@ interface GraphConnection {
   fromLane: number;
   toLane: number;
   color: string;
+  type: 'branch' | 'merge';
 }
 
-interface LaneConnectionState {
-  incoming: GraphConnection[];
-  outgoing: GraphConnection[];
-  passing: GraphConnection[];
+interface CommitLaneInfo {
+  lane: number;
+  branch: string;
+}
+
+interface BranchLegendEntry {
+  name: string;
+  color: string;
 }
 
 const LANE_COLUMN_WIDTH = 72;
+const TURN_RADIUS = 10;
 
 const getBranchColor = (branchName: string): string => {
   const predefined: Record<string, string> = {
@@ -89,96 +88,204 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
   );
 
   // Calculate lanes and connections
-  const { branchLanes, commitLaneMap, connections } = useMemo(() => {
-    const lanes: BranchLane[] = [];
-    const laneIndexByName: Record<string, number> = {};
-    const laneMap: Record<string, number> = {};
+  const {
+    commitLaneInfo,
+    laneCount,
+    branchLegend,
+    connections
+  } = useMemo(() => {
     const commitIndexMap: Record<string, number> = {};
-
     sortedCommits.forEach((commit, index) => {
-      const primaryBranch = commit.branches[0] || 'detached';
       commitIndexMap[commit.id] = index;
-
-      if (laneIndexByName[primaryBranch] === undefined) {
-        laneIndexByName[primaryBranch] = lanes.length;
-        lanes.push({
-          name: primaryBranch,
-          color: getBranchColor(primaryBranch),
-          firstCommitIndex: index,
-          lastCommitIndex: index
-        });
-      } else {
-        const lane = lanes[laneIndexByName[primaryBranch]];
-        lane.lastCommitIndex = Math.max(lane.lastCommitIndex, index);
-      }
-
-      laneMap[commit.id] = laneIndexByName[primaryBranch];
     });
 
-    const connectionStates: LaneConnectionState[][] = sortedCommits.map(() =>
-      lanes.map(() => ({ incoming: [], outgoing: [], passing: [] }))
-    );
+    const chronologicalCommits = [...sortedCommits].reverse();
+    const laneBranchNames: (string | null)[] = [];
+    laneBranchNames[0] = 'main';
+
+    const branchLaneMap = new Map<string, number>();
+    const branchCommitsMap = new Map<string, string[]>();
+    branchLaneMap.set('main', 0);
+    branchLaneMap.set('master', 0);
+
+    const isMainBranch = (branch: string) => branch === 'main' || branch === 'master';
+
+    const recordCommitForBranch = (branch: string, commitId: string) => {
+      const existing = branchCommitsMap.get(branch);
+      if (existing) {
+        existing.push(commitId);
+      } else {
+        branchCommitsMap.set(branch, [commitId]);
+      }
+    };
+
+    const shiftLanesRight = (startIndex: number) => {
+      if (startIndex < 1) {
+        return;
+      }
+
+      laneBranchNames.splice(startIndex, 0, null);
+
+      branchLaneMap.forEach((lane, branch) => {
+        if (lane >= startIndex) {
+          const newLane = lane + 1;
+          branchLaneMap.set(branch, newLane);
+
+          const commitIds = branchCommitsMap.get(branch);
+          if (commitIds) {
+            commitIds.forEach((commitId) => {
+              const info = commitLaneInfo[commitId];
+              if (info) {
+                info.lane = newLane;
+              }
+            });
+          }
+        }
+      });
+    };
+
+    const commitLaneInfo: Record<string, CommitLaneInfo> = {};
+    const branchColors = new Map<string, string>();
+    const mergeConnections = new Set<string>();
+
+    chronologicalCommits.forEach((commit) => {
+      const branches = commit.branches.length > 0 ? commit.branches : ['detached'];
+      const primaryBranch =
+        branches.find((branch) => isMainBranch(branch)) ?? branches[0] ?? 'detached';
+
+      let laneIndex: number;
+      if (isMainBranch(primaryBranch)) {
+        laneIndex = 0;
+        if (!branchLaneMap.has(primaryBranch)) {
+          branchLaneMap.set(primaryBranch, 0);
+        }
+        if (!laneBranchNames[0]) {
+          laneBranchNames[0] = primaryBranch;
+        }
+      } else {
+        const existingLane = branchLaneMap.get(primaryBranch);
+        if (existingLane !== undefined) {
+          laneIndex = existingLane;
+        } else {
+          const parentLane = commit.parents
+            .map((parentId) => commitLaneInfo[parentId]?.lane)
+            .find((lane) => lane !== undefined);
+
+          const baseLane = parentLane ?? laneBranchNames.length - 1;
+          const desiredLane = Math.max(baseLane + 1, 1);
+
+          if (desiredLane >= laneBranchNames.length) {
+            while (laneBranchNames.length <= desiredLane) {
+              laneBranchNames.push(null);
+            }
+          }
+
+          if (laneBranchNames[desiredLane]) {
+            shiftLanesRight(desiredLane);
+          }
+
+          laneIndex = desiredLane;
+          branchLaneMap.set(primaryBranch, laneIndex);
+          laneBranchNames[laneIndex] = primaryBranch;
+        }
+      }
+
+      commitLaneInfo[commit.id] = { lane: laneIndex, branch: primaryBranch };
+      branchColors.set(primaryBranch, getBranchColor(primaryBranch));
+      recordCommitForBranch(primaryBranch, commit.id);
+
+      if (!isMainBranch(primaryBranch)) {
+        laneBranchNames[laneIndex] = primaryBranch;
+      }
+
+      if (commit.parents.length > 1) {
+        commit.parents.forEach((parentId) => {
+          const parentInfo = commitLaneInfo[parentId];
+          if (!parentInfo) {
+            return;
+          }
+          if (parentInfo.lane === laneIndex) {
+            return;
+          }
+          if (parentInfo.lane === 0 && isMainBranch(parentInfo.branch)) {
+            return;
+          }
+
+          mergeConnections.add(`${commit.id}->${parentId}`);
+          branchLaneMap.delete(parentInfo.branch);
+          laneBranchNames[parentInfo.lane] = null;
+        });
+      }
+    });
+
+    const laneCount = laneBranchNames.length;
+
+    const branchLegend: BranchLegendEntry[] = Array.from(branchColors.entries())
+      .filter(([name]) => name !== 'detached')
+      .map(([name, color]) => ({ name, color }))
+      .sort((a, b) => {
+        if (isMainBranch(a.name)) return -1;
+        if (isMainBranch(b.name)) return 1;
+        return a.name.localeCompare(b.name);
+      });
 
     const connections: GraphConnection[] = [];
 
     sortedCommits.forEach((commit, fromIndex) => {
-      const fromLane = laneMap[commit.id];
-
-      if (fromLane === undefined) {
+      const fromInfo = commitLaneInfo[commit.id];
+      if (!fromInfo) {
         return;
       }
 
       commit.parents.forEach((parentId) => {
         const toIndex = commitIndexMap[parentId];
+        const toInfo = commitLaneInfo[parentId];
 
-        if (toIndex === undefined) {
+        if (toIndex === undefined || !toInfo) {
           return;
         }
 
-        const toLane = laneMap[parentId] ?? fromLane;
-        const color = lanes[fromLane]?.color ?? '#6B7280';
-        const connection: GraphConnection = {
+        if (fromInfo.lane === toInfo.lane) {
+          return;
+        }
+
+        const key = `${commit.id}->${parentId}`;
+        const type: GraphConnection['type'] = mergeConnections.has(key)
+          ? 'merge'
+          : 'branch';
+
+        const color =
+          type === 'merge'
+            ? getBranchColor(toInfo.branch)
+            : getBranchColor(fromInfo.branch);
+
+        connections.push({
           id: `${commit.id}-${parentId}`,
           fromIndex,
           toIndex,
-          fromLane,
-          toLane,
-          color
-        };
-
-        connections.push(connection);
+          fromLane: fromInfo.lane,
+          toLane: toInfo.lane,
+          color,
+          type
+        });
       });
     });
 
-    connections.forEach((connection) => {
-      const { fromIndex, toIndex, fromLane, toLane } = connection;
-
-      const fromLaneState = connectionStates[fromIndex]?.[fromLane];
-      const toLaneState = connectionStates[toIndex]?.[toLane];
-
-      fromLaneState?.outgoing.push(connection);
-
-      for (let row = fromIndex + 1; row < toIndex; row += 1) {
-        const passingLaneState = connectionStates[row]?.[fromLane];
-        passingLaneState?.passing.push(connection);
-      }
-
-      toLaneState?.incoming.push(connection);
-    });
-
     return {
-      branchLanes: lanes,
-      commitLaneMap: laneMap,
+      commitLaneInfo,
+      laneCount,
+      branchLegend,
       connections
     };
   }, [sortedCommits]);
 
   // Calculate node positions for SVG
   const ROW_HEIGHT = 64;
+  const COMMIT_NODE_RADIUS = 24;
   const nodePositions = useMemo(() => {
     const positions: Record<string, { x: number; y: number; lane: number; row: number }> = {};
     sortedCommits.forEach((commit, rowIndex) => {
-      const laneIndex = commitLaneMap[commit.id];
+      const laneIndex = commitLaneInfo[commit.id]?.lane ?? 0;
       positions[commit.id] = {
         x: laneIndex * LANE_COLUMN_WIDTH + LANE_COLUMN_WIDTH / 2,
         y: rowIndex * ROW_HEIGHT + ROW_HEIGHT / 2,
@@ -187,101 +294,157 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
       };
     });
     return positions;
-  }, [sortedCommits, commitLaneMap]);
+  }, [sortedCommits, commitLaneInfo]);
 
   // SVG connection lines
-  const CORNER_RADIUS = 10;
   const svgConnections = useMemo(() => {
     const lines: { id: string; path: string; color: string }[] = [];
-    // Draw vertical lines for each lane (continuous)
-    branchLanes.forEach((lane, laneIndex) => {
-      let prevY: number | null = null;
-      sortedCommits.forEach((commit, rowIndex) => {
-        if (commitLaneMap[commit.id] === laneIndex) {
-          const pos = nodePositions[commit.id];
-          if (prevY !== null) {
-            lines.push({
-              id: `lane-${lane.name}-v-${rowIndex}`,
-              path: `M ${pos.x} ${prevY} L ${pos.x} ${pos.y}`,
-              color: lane.color
-            });
-          }
-          prevY = pos.y;
-        }
-      });
-    });
-    // Draw connections (forks and merges) with 90-degree turns and rounded corners (outside)
-    connections.forEach((connection) => {
-      const fromPos = nodePositions[sortedCommits[connection.fromIndex].id];
-      const toPos = nodePositions[sortedCommits[connection.toIndex].id];
-      if (!fromPos || !toPos) return;
-      const isBranchStart = branchLanes[toPos.lane]?.firstCommitIndex === connection.toIndex && fromPos.lane !== toPos.lane;
-      if (isBranchStart) {
-        // Branch start: fork at parent node's Y position, 90-degree turn with rounded corner (outside)
-        const horizontalDir = Math.sign(toPos.x - fromPos.x);
-        const verticalDir = Math.sign(toPos.y - fromPos.y);
-        const cornerX = toPos.x;
-        const cornerY = fromPos.y;
-        // Move horizontally, stop CORNER_RADIUS before the turn
-        const hStopX = cornerX - horizontalDir * CORNER_RADIUS;
-        // Move vertically, start CORNER_RADIUS after the turn
-        const vStartY = cornerY + verticalDir * CORNER_RADIUS;
-        // Sweep flag: 1 if both directions are the same (right-down, left-up), else 0
-        const arcSweep = (horizontalDir === 1 && verticalDir === 1) || (horizontalDir === -1 && verticalDir === -1) ? 1 : 0;
-        lines.push({
-          id: connection.id + '-branch-h',
-          path: `M ${fromPos.x} ${fromPos.y} H ${hStopX}`,
-          color: connection.color
-        });
 
-        // Arc for the outside corner
+    const getAnchors = (pos: { x: number; y: number }) => ({
+      top: { x: pos.x, y: pos.y - COMMIT_NODE_RADIUS },
+      bottom: { x: pos.x, y: pos.y + COMMIT_NODE_RADIUS },
+      left: { x: pos.x - COMMIT_NODE_RADIUS, y: pos.y },
+      right: { x: pos.x + COMMIT_NODE_RADIUS, y: pos.y },
+      center: { x: pos.x, y: pos.y }
+    });
+
+    const createRoundedHorizontalVerticalPath = (
+      startX: number,
+      startY: number,
+      endX: number,
+      endY: number
+    ) => {
+      const deltaX = endX - startX;
+      const deltaY = endY - startY;
+      if (deltaX === 0 || deltaY === 0) {
+        return `M ${startX} ${startY} ${deltaX === 0 ? 'V' : 'H'} ${
+          deltaX === 0 ? endY : endX
+        }`;
+      }
+
+      const horizontalDirection = deltaX >= 0 ? 1 : -1;
+      const verticalDirection = deltaY >= 0 ? 1 : -1;
+      const radius = Math.min(
+        TURN_RADIUS,
+        Math.abs(deltaX),
+        Math.abs(deltaY)
+      );
+
+      if (radius === 0) {
+        return `M ${startX} ${startY} H ${endX} V ${endY}`;
+      }
+
+      const cornerStartX = endX - horizontalDirection * radius;
+      const arcEndY = startY + verticalDirection * radius;
+      const sweepFlag = verticalDirection === 1 ? 1 : 0;
+
+      return `M ${startX} ${startY} H ${cornerStartX} A ${radius} ${radius} 0 0 ${sweepFlag} ${endX} ${arcEndY} V ${endY}`;
+    };
+
+    const createRoundedVerticalHorizontalPath = (
+      startX: number,
+      startY: number,
+      endX: number,
+      endY: number
+    ) => {
+      const deltaX = endX - startX;
+      const deltaY = endY - startY;
+      if (deltaX === 0 || deltaY === 0) {
+        return `M ${startX} ${startY} ${deltaY === 0 ? 'H' : 'V'} ${
+          deltaY === 0 ? endX : endY
+        }`;
+      }
+
+      const horizontalDirection = deltaX >= 0 ? 1 : -1;
+      const verticalDirection = deltaY >= 0 ? 1 : -1;
+      const radius = Math.min(
+        TURN_RADIUS,
+        Math.abs(deltaX),
+        Math.abs(deltaY)
+      );
+
+      if (radius === 0) {
+        return `M ${startX} ${startY} V ${endY} H ${endX}`;
+      }
+
+      const cornerStartY = endY - verticalDirection * radius;
+      const arcEndX = startX + horizontalDirection * radius;
+      const sweepFlag = horizontalDirection === 1 ? 1 : 0;
+
+      return `M ${startX} ${startY} V ${cornerStartY} A ${radius} ${radius} 0 0 ${sweepFlag} ${arcEndX} ${endY} H ${endX}`;
+    };
+
+    const laneStates: Record<number, { nextBottom: number; branch: string }> = {};
+
+    sortedCommits.forEach((commit) => {
+      const laneInfo = commitLaneInfo[commit.id];
+      if (!laneInfo) {
+        return;
+      }
+
+      const pos = nodePositions[commit.id];
+      const anchors = getAnchors(pos);
+      const laneState = laneStates[laneInfo.lane];
+
+      if (laneState && laneState.branch === laneInfo.branch) {
         lines.push({
-          id: connection.id + '-branch-arc',
-          path: `M ${hStopX} ${cornerY} A ${CORNER_RADIUS} ${CORNER_RADIUS} 0 0 ${arcSweep} ${cornerX} ${vStartY}`,
-          color: connection.color
-        });
-        // Vertical segment
-        lines.push({
-          id: connection.id + '-branch-v',
-          path: `M ${cornerX} ${vStartY} V ${toPos.y}`,
-          color: connection.color
-        });
-      } else if (fromPos.lane === toPos.lane) {
-        // Already handled by vertical lane lines above
-      } else {
-        // Merge: 90-degree turn at child Y with rounded corner (outside)
-        const horizontalDir = Math.sign(toPos.x - fromPos.x);
-        const verticalDir = Math.sign(toPos.y - fromPos.y);
-        const cornerX = toPos.x;
-        const cornerY = toPos.y;
-        // Move vertically, stop CORNER_RADIUS before the turn
-        const vStopY = cornerY - verticalDir * CORNER_RADIUS;
-        // Move horizontally, start CORNER_RADIUS after the turn
-        const hStartX = fromPos.x + horizontalDir * CORNER_RADIUS;
-        // Sweep flag: 1 for right-down, left-up; 0 for right-up, left-down
-        // For outside arc, sweep = (horizontalDir !== verticalDir ? 1 : 0)
-        const arcSweep = horizontalDir !== verticalDir ? 1 : 0;
-        lines.push({
-          id: connection.id + '-merge-v',
-          path: `M ${fromPos.x} ${fromPos.y} V ${vStopY}`,
-          color: connection.color
-        });
-        // Arc for the outside corner
-        lines.push({
-          id: connection.id + '-merge-arc',
-          path: `M ${fromPos.x} ${vStopY} A ${CORNER_RADIUS} ${CORNER_RADIUS} 0 0 ${arcSweep} ${hStartX} ${cornerY}`,
-          color: connection.color
-        });
-        // Horizontal segment
-        lines.push({
-          id: connection.id + '-merge-h',
-          path: `M ${hStartX} ${cornerY} H ${cornerX}`,
-          color: connection.color
+          id: `lane-${laneInfo.lane}-${commit.id}`,
+          path: `M ${anchors.top.x} ${anchors.top.y} V ${laneState.nextBottom}`,
+          color: getBranchColor(laneInfo.branch)
         });
       }
+
+      laneStates[laneInfo.lane] = {
+        nextBottom: anchors.bottom.y,
+        branch: laneInfo.branch
+      };
     });
+
+    connections.forEach((connection) => {
+      const childCommit = sortedCommits[connection.fromIndex];
+      const parentCommit = sortedCommits[connection.toIndex];
+
+      const childPos = nodePositions[childCommit.id];
+      const parentPos = nodePositions[parentCommit.id];
+
+      if (!childPos || !parentPos) {
+        return;
+      }
+
+      const childAnchors = getAnchors(childPos);
+      const parentAnchors = getAnchors(parentPos);
+
+      const isChildBelowParent = childPos.y > parentPos.y;
+
+      if (connection.type === 'merge') {
+        const startAnchor = isChildBelowParent ? parentAnchors.bottom : parentAnchors.top;
+        const startX = startAnchor.x;
+        const startY = startAnchor.y;
+        const mergeY = childAnchors.right.y;
+        const mergeX = childAnchors.right.x;
+
+        lines.push({
+          id: `${connection.id}-${connection.type}`,
+          path: createRoundedVerticalHorizontalPath(startX, startY, mergeX, mergeY),
+          color: connection.color
+        });
+        return;
+      }
+
+      const startX = parentAnchors.right.x;
+      const startY = parentAnchors.right.y;
+      const endX = childPos.x;
+      const endY = childAnchors.bottom.y;
+
+      lines.push({
+        id: `${connection.id}-${connection.type}`,
+        path: createRoundedHorizontalVerticalPath(startX, startY, endX, endY),
+        color: connection.color
+      });
+    });
+
     return lines;
-  }, [connections, nodePositions, sortedCommits, branchLanes, commitLaneMap]);
+  }, [connections, nodePositions, sortedCommits, commitLaneInfo]);
 
   const registerNodeRef = useCallback(
     (commitId: string) => (element: HTMLDivElement | null) => {
@@ -324,27 +487,26 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
 
   const timelineColumns = useMemo(
     () =>
-      branchLanes.length > 0
-        ? `repeat(${branchLanes.length}, ${LANE_COLUMN_WIDTH}px)`
-        : '1fr',
-    [branchLanes.length]
+      laneCount > 0 ? `repeat(${laneCount}, ${LANE_COLUMN_WIDTH}px)` : '1fr',
+    [laneCount]
   );
 
-  const renderLaneCell = (
-    commit: GitCommit,
-    lane: BranchLane,
-    laneIndex: number
-  ) => {
-    const commitLane = commitLaneMap[commit.id];
-    const isCommitLane = laneIndex === commitLane;
+  const renderLaneCell = (commit: GitCommit, laneIndex: number) => {
+    const laneInfo = commitLaneInfo[commit.id];
+    const isCommitLane = laneInfo?.lane === laneIndex;
+    const branchColor = laneInfo ? getBranchColor(laneInfo.branch) : '#6B7280';
 
     return (
-      <div key={lane.name} className="relative flex items-center justify-center" style={{ height: ROW_HEIGHT }}>
+      <div
+        key={`lane-${laneIndex}`}
+        className="relative flex items-center justify-center"
+        style={{ height: ROW_HEIGHT }}
+      >
         {isCommitLane && (
           <div ref={registerNodeRef(commit.id)} className="relative z-20 flex items-center justify-center" style={{ height: ROW_HEIGHT }}>
             <CommitNode
               commit={commit}
-              branchColor={lane.color}
+              branchColor={branchColor}
               onClick={() => onCommitClick(commit)}
               onContextMenu={(event) => handleContextMenu(event, commit)}
             />
@@ -365,7 +527,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             </h3>
           </div>
           <div className="space-y-3 px-4 py-4">
-            {branchLanes.map((lane) => (
+            {branchLegend.map((lane) => (
               <div key={lane.name} className="flex items-center gap-3">
                 <span
                   className="h-3 w-3 rounded-full"
@@ -376,7 +538,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                 </span>
               </div>
             ))}
-            {branchLanes.length === 0 && (
+            {branchLegend.length === 0 && (
               <div className="text-sm text-gray-500">No branches detected</div>
             )}
           </div>
@@ -390,9 +552,9 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             {/* SVG overlay for all connections */}
             <svg
               className="pointer-events-none absolute inset-0 z-10"
-              width={branchLanes.length * LANE_COLUMN_WIDTH}
+              width={laneCount * LANE_COLUMN_WIDTH}
               height={sortedCommits.length * ROW_HEIGHT}
-              viewBox={`0 0 ${branchLanes.length * LANE_COLUMN_WIDTH} ${sortedCommits.length * ROW_HEIGHT}`}
+              viewBox={`0 0 ${laneCount * LANE_COLUMN_WIDTH} ${sortedCommits.length * ROW_HEIGHT}`}
             >
               {svgConnections.map((line) => (
                 <path
@@ -413,9 +575,9 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                 className="grid border-b border-gray-800 bg-gray-900/60 hover:bg-gray-900 transition-colors"
                 style={{ gridTemplateColumns: `${timelineColumns} minmax(0, 1fr)`, height: ROW_HEIGHT }}
               >
-                {branchLanes.length > 0 ? (
-                  branchLanes.map((lane, laneIndex) =>
-                    renderLaneCell(commit, lane, laneIndex)
+                {laneCount > 0 ? (
+                  Array.from({ length: laneCount }, (_, laneIndex) =>
+                    renderLaneCell(commit, laneIndex)
                   )
                 ) : (
                   <div style={{ height: ROW_HEIGHT }} />


### PR DESCRIPTION
## Summary
- insert lane slots dynamically so new branches always start immediately beside their parent
- shift occupied lanes to the right when necessary and update stored commit locations to prevent connector crossings
- keep lane bookkeeping in sync by recording processed commits per branch and releasing lanes once merges complete
- add 10px rounded elbows to branch and merge connectors so every 90° turn is smoothly curved

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d5b6f2df8c832894425aa77cddc5f3